### PR TITLE
Nil literal

### DIFF
--- a/src/compiler/Emit/BlockEmitter.cs
+++ b/src/compiler/Emit/BlockEmitter.cs
@@ -152,6 +152,13 @@ internal class BlockEmitter(
         return default;
     }
 
+    protected override int VisitNilExpression(NilExpression node)
+    {
+        Code.PushNil();
+
+        return default;
+    }
+
     protected override int VisitLoopExpression(LoopExpression node)
     {
         // Setting the start offset as the address of the enter temp frame instruction

--- a/src/compiler/Nodes/Nodes.cs
+++ b/src/compiler/Nodes/Nodes.cs
@@ -294,6 +294,11 @@ public sealed class NumberExpression : Expression
     public override IEnumerable<Node> Children => [];
 }
 
+public sealed class NilExpression : Expression
+{
+    public override IEnumerable<Node> Children => [];
+}
+
 public enum UnaryKind
 {
     Identity,

--- a/src/compiler/Nodes/Visitor.cs
+++ b/src/compiler/Nodes/Visitor.cs
@@ -171,6 +171,7 @@ public abstract class Visitor<T>
         LambdaExpression x => VisitLambdaExpression(x),
         LoopExpression x => VisitLoopExpression(x),
         NumberExpression x => VisitNumberExpression(x),
+        NilExpression x => VisitNilExpression(x),
         ReturnExpression x => VisitReturnExpression(x),
         StringExpression x => VisitStringExpression(x),
         TupleExpression x => VisitTupleExpression(x),
@@ -265,4 +266,6 @@ public abstract class Visitor<T>
     protected virtual T VisitBoolExpression(BoolExpression node) => GetDefault(node);
 
     protected virtual T VisitNumberExpression(NumberExpression node) => GetDefault(node);
+
+    protected virtual T VisitNilExpression(NilExpression node) => GetDefault(node);
 }

--- a/src/compiler/Parsing/ParenthesizedExpression.cs
+++ b/src/compiler/Parsing/ParenthesizedExpression.cs
@@ -126,14 +126,7 @@ internal sealed partial class Parser
 
         if (expressions.Length == 0)
         {
-            // () is just invalid syntax.
-            
-            var diagnostic = ParseDiagnostics.ExpectedKinds.Format(
-                SyntaxFacts.CanBeginExpression,
-                closeParen.Location);
-            ReportDiagnostic(diagnostic);
-
-            return new ErrorExpression()
+            return new NilExpression()
             {
                 Ast = Ast,
                 Location = parensLocation


### PR DESCRIPTION
Add nil expressions with the syntax `()`. Fixes #16.
