### PR TITLE
Optional else

### DIFF
--- a/src/compiler-tests/Parsing/IfExpressionTests.cs
+++ b/src/compiler-tests/Parsing/IfExpressionTests.cs
@@ -1,0 +1,73 @@
+using Noa.Compiler.Nodes;
+using Noa.Compiler.Tests;
+
+namespace Noa.Compiler.Parsing.Tests;
+
+public sealed class IfExpressionTests
+{
+    [Fact]
+    public void Else_IsRequired_InExpressions()
+    {
+        var p = ParseAssertion.Create(
+            "if true {}",
+            p => p.ParseExpressionOrError());
+        
+        p.Diagnostics.DiagnosticsShouldBe([
+            (ParseDiagnostics.ElseOmitted.Id, new Location("test-input", 0, 2))
+        ], ignoreAdditional: true);
+
+        p.N<IfExpression>();
+        {
+            p.N<BoolExpression>();
+
+            p.N<BlockExpression>();
+
+            p.N<ElseClause>();
+            {
+                p.N<BlockExpression>();
+            }
+        }
+
+        p.End();
+    }
+
+    [Fact]
+    public void Else_IsNotRequired_InStatements()
+    {
+        var p = ParseAssertion.Create(
+            "if true {}",
+            p => p.ParseRoot());
+
+        p.N<Root>();
+        {
+            p.N<IfExpression>();
+            {
+                p.N<BoolExpression>();
+
+                p.N<BlockExpression>();
+            }
+        }
+
+        p.End();
+    }
+    
+    [Fact]
+    public void Else_IsAllowed_InExpressions()
+    {
+        var p = ParseAssertion.Create(
+            "if true {} else {}",
+            p => p.ParseExpressionOrError());
+        
+        p.N<IfExpression>();
+        {
+            p.N<BoolExpression>();
+
+            p.N<BlockExpression>();
+
+            p.N<ElseClause>();
+            {
+                p.N<BlockExpression>();
+            }
+        }
+    }
+}

--- a/src/compiler-tests/Parsing/IfExpressionTests.cs
+++ b/src/compiler-tests/Parsing/IfExpressionTests.cs
@@ -70,4 +70,25 @@ public sealed class IfExpressionTests
             }
         }
     }
+
+    [Fact]
+    public void IfWithoutElse_InBlock_ParsesAsStatement()
+    {
+        var p = ParseAssertion.Create(
+            "if true {}",
+            p => p.ParseRoot());
+
+        p.N<Root>();
+        {
+            p.N<ExpressionStatement>();
+            {
+                p.N<IfExpression>();
+                {
+                    p.N<BoolExpression>();
+
+                    p.N<BlockExpression>();
+                }
+            }
+        }
+    }
 }

--- a/src/compiler-tests/Parsing/RootAndBlockExpressionTests.cs
+++ b/src/compiler-tests/Parsing/RootAndBlockExpressionTests.cs
@@ -453,7 +453,10 @@ public class RootAndBlockExpressionTests
 
                 p.N<BlockExpression>();
 
-                p.N<BlockExpression>();
+                p.N<ElseClause>();
+                {
+                    p.N<BlockExpression>();
+                }
             }
         }
 
@@ -529,7 +532,10 @@ public class RootAndBlockExpressionTests
 
                     p.N<BlockExpression>();
 
-                    p.N<BlockExpression>();
+                    p.N<ElseClause>();
+                    {
+                        p.N<BlockExpression>();
+                    }
                 }
             }
 
@@ -620,7 +626,10 @@ public class RootAndBlockExpressionTests
 
                     p.N<BlockExpression>();
 
-                    p.N<BlockExpression>();
+                    p.N<ElseClause>();
+                    {
+                        p.N<BlockExpression>();
+                    }
                 }
             }
 

--- a/src/compiler/ControlFlow/ControlFlowMarker.cs
+++ b/src/compiler/ControlFlow/ControlFlowMarker.cs
@@ -124,7 +124,9 @@ file sealed class Visitor(Reachability current, CancellationToken cancellationTo
         Visit(node.Condition);
         
         var ifTrueNext = CreateSubVisitor().Visit(node.IfTrue).Next;
-        var ifFalseNext = CreateSubVisitor().Visit(node.IfFalse).Next;
+        var ifFalseNext = node.Else is { IfFalse: var ifFalse }
+            ? CreateSubVisitor().Visit(ifFalse).Next
+            : current;
 
         var next = ifTrueNext | ifFalseNext;
 

--- a/src/compiler/Emit/BlockEmitter.cs
+++ b/src/compiler/Emit/BlockEmitter.cs
@@ -161,16 +161,31 @@ internal class BlockEmitter(
     {
         Visit(node.Condition);
 
-        var jumpToTrue = Code.JumpIf();
+        if (node.Else is { IfFalse: var ifFalse })
+        {
+            var jumpToTrue = Code.JumpIf();
 
-        Visit(node.IfFalse);
+            Visit(ifFalse);
         
-        var jumpToEnd = Code.Jump();
+            var jumpToEnd = Code.Jump();
         
-        jumpToTrue.SetAddress(Code.AddressOffset);
-        Visit(node.IfTrue);
+            jumpToTrue.SetAddress(Code.AddressOffset);
+            Visit(node.IfTrue);
         
-        jumpToEnd.SetAddress(Code.AddressOffset);
+            jumpToEnd.SetAddress(Code.AddressOffset);
+        }
+        else
+        {
+            Code.Not();
+            var jumpToEnd = Code.JumpIf();
+            
+            Visit(node.IfTrue);
+            Code.Pop();
+            
+            jumpToEnd.SetAddress(Code.AddressOffset);
+
+            Code.PushNil();
+        }
     }
 
     protected override void VisitCallExpression(CallExpression node)

--- a/src/compiler/Generated/Nodes.g.cs
+++ b/src/compiler/Generated/Nodes.g.cs
@@ -124,11 +124,18 @@ public sealed partial class IfExpression : Expression
 
     public required BlockExpression IfTrue { get; init; }
 
+    public required ElseClause? Else { get; init; }
+
+    public override IEnumerable<Node> Children => [Condition, IfTrue, ..EmptyIfNull(Else)];
+}
+
+public sealed partial class ElseClause : Node
+{
     public required Token ElseKeyword { get; init; }
 
     public required BlockExpression IfFalse { get; init; }
 
-    public override IEnumerable<Node> Children => [Condition, IfTrue, IfFalse];
+    public override IEnumerable<Node> Children => [IfFalse];
 }
 
 public sealed partial class LoopExpression : Expression

--- a/src/compiler/Generated/Visitor.g.cs
+++ b/src/compiler/Generated/Visitor.g.cs
@@ -22,6 +22,9 @@ public abstract partial class Visitor
         case Expression x:
             VisitExpression(x);
             break;
+        case ElseClause x:
+            VisitElseClause(x);
+            break;
         default:
             throw new UnreachableException();
         }
@@ -190,6 +193,11 @@ public abstract partial class Visitor
     {
         Visit(node.Condition);
         Visit(node.IfTrue);
+        if (node.Else is not null) Visit(node.Else);
+    }
+
+    protected virtual void VisitElseClause(ElseClause node)
+    {
         Visit(node.IfFalse);
     }
 

--- a/src/compiler/Generated/Visitor_T.g.cs
+++ b/src/compiler/Generated/Visitor_T.g.cs
@@ -14,6 +14,7 @@ public abstract partial class Visitor<T>
         Statement x => VisitStatement(x),
         Parameter x => VisitParameter(x),
         Expression x => VisitExpression(x),
+        ElseClause x => VisitElseClause(x),
         _ => throw new UnreachableException()
     };
 
@@ -142,6 +143,13 @@ public abstract partial class Visitor<T>
     {
         Visit(node.Condition);
         Visit(node.IfTrue);
+        if (node.Else is not null) Visit(node.Else);
+
+        return GetDefault(node);
+    }
+
+    protected virtual T VisitElseClause(ElseClause node)
+    {
         Visit(node.IfFalse);
 
         return GetDefault(node);

--- a/src/compiler/Parsing/Blocks.cs
+++ b/src/compiler/Parsing/Blocks.cs
@@ -42,9 +42,13 @@ internal sealed partial class Parser
             // If the statement is null then the expression should never be null.
             if (expression is null) throw new UnreachableException();
 
-            // If the token after the expression is not a semicolon and cannot start another statement,
-            // then it's most likely a trailing expression.
+            // If the token after the expression is not a semicolon, cannot start another statement,
+            // and is allowed as a trailing expression, then it's most likely a trailing expression.
+            // We need to check whether the expression is allowed as a trailing expression because
+            // the expression might be an if expression without an else clause, which is only allowed
+            // as an expression statement.
             if (allowTrailingExpression &&
+                expression.IsAllowedAsTrailingExpression() &&
                 Current.Kind is not TokenKind.Semicolon &&
                 !SyntaxFacts.CanBeginStatement.Contains(Current.Kind))
             {

--- a/src/compiler/Parsing/Blocks.cs
+++ b/src/compiler/Parsing/Blocks.cs
@@ -119,7 +119,7 @@ internal sealed partial class Parser
         }
         
         // Try parse a flow control expression.
-        if (ParseFlowControlExpressionOrNull() is { } flowControlExpression)
+        if (ParseFlowControlExpressionOrNull(FlowControlExpressionContext.Statement) is { } flowControlExpression)
         {
             return (null, flowControlExpression);
         }

--- a/src/compiler/Parsing/Expressions.cs
+++ b/src/compiler/Parsing/Expressions.cs
@@ -309,19 +309,33 @@ internal sealed partial class Parser
 
         var ifTrue = ParseBlockExpression();
 
-        var @else = Expect(TokenKind.Else);
+        var elseClause = null as ElseClause;
+        if (Current.Kind is TokenKind.Else)
+        {
+            var @else = Advance();
+            
+            var ifFalse = ParseBlockExpression();
 
-        var ifFalse = ParseBlockExpression();
+            elseClause = new()
+            {
+                Ast = Ast,
+                Location = new(Source.Name, @else.Location.Start, ifFalse.Location.End),
+                ElseKeyword = @else,
+                IfFalse = ifFalse
+            };
+        }
 
         return new()
         {
             Ast = Ast,
-            Location = new(Source.Name, @if.Location.Start, ifFalse.Location.End),
+            Location = new(
+                Source.Name,
+                @if.Location.Start,
+                elseClause?.Location.End ?? ifTrue.Location.End),
             IfKeyword = @if,
             Condition = condition,
             IfTrue = ifTrue,
-            ElseKeyword = @else,
-            IfFalse = ifFalse
+            Else = elseClause
         };
     }
 

--- a/src/compiler/Parsing/FlowControlExpressionContext.cs
+++ b/src/compiler/Parsing/FlowControlExpressionContext.cs
@@ -1,0 +1,7 @@
+namespace Noa.Compiler.Parsing;
+
+internal enum FlowControlExpressionContext
+{
+    Expression,
+    Statement,
+}

--- a/src/compiler/Parsing/ParseDiagnostics.cs
+++ b/src/compiler/Parsing/ParseDiagnostics.cs
@@ -83,4 +83,15 @@ internal static class ParseDiagnostics
                 .Emphasized("left-hand side of an assignment statement")
                 .Raw("."),
             Severity.Error);
+
+    public static DiagnosticTemplate ElseOmitted { get; } =
+        DiagnosticTemplate.Create(
+            "NOA-SYN-007",
+            page => page
+                .Raw("The ")
+                .Keyword("else branch")
+                .Raw(" of an ")
+                .Keyword("if expression")
+                .Raw(" can only be omitted when the expression is used as a statement."),
+            Severity.Error);
 }

--- a/src/compiler/Parsing/SyntaxFacts.cs
+++ b/src/compiler/Parsing/SyntaxFacts.cs
@@ -158,6 +158,13 @@ internal static class SyntaxFacts
         or LoopExpression;
 
     /// <summary>
+    /// Returns whether an expression is allowed as a trailing expression at the end of a block.
+    /// </summary>
+    /// <param name="expression">The expression to check.</param>
+    public static bool IsAllowedAsTrailingExpression(this Expression expression) => expression
+        is not IfExpression { Else: null };
+
+    /// <summary>
     /// Returns whether an expression is a valid l-value.
     /// </summary>
     /// <param name="expression">The expression to check.</param>

--- a/src/compiler/gen/nodes.xml
+++ b/src/compiler/gen/nodes.xml
@@ -72,6 +72,10 @@
     <Value Name="IfKeyword" Type="Token" Primitive="true"/>
     <Value Name="Condition" Type="Expression"/>
     <Value Name="IfTrue" Type="BlockExpression"/>
+    <Value Name="Else" Type="ElseClause" Optional="true"/>
+  </Node>
+  
+  <Node Name="ElseClause">
     <Value Name="ElseKeyword" Type="Token" Primitive="true"/>
     <Value Name="IfFalse" Type="BlockExpression"/>
   </Node>

--- a/syntax.ebnf
+++ b/syntax.ebnf
@@ -5,14 +5,20 @@ root = statement* expression? ;
 statement = functionDeclaration
           | letDeclaration
           | assignmentStatement
-          | callExpression      ';'
-          | returnExpression    ';'
-          | breakExpression     ';'
-          | continueExpression  ';'
-          | blockExpression
-          | ifExpression
-          | loopExpression
+          | expressionStatement ';'
+          | flowControlStatement
           ;
+
+expressionStatement = callExpression
+                    | returnExpression
+                    | breakExpression
+                    | continueExpression
+                    ;
+
+flowControlStatement = blockExpression
+                     | ifExpression
+                     | loopExpression
+                     ;
 
 
 


### PR DESCRIPTION
Make `else` clause of if-expressions optional when the expression is used as an expression statement. Fixes #15.