### PR TITLE
Add TextSpan

### DIFF
--- a/src/cli/CommandBase.cs
+++ b/src/cli/CommandBase.cs
@@ -39,8 +39,8 @@ public abstract class CommandBase(IAnsiConsole console)
             .GetValueOrDefault(Severity.Error, [])
             .Concat(collectedDiagnostics.GetValueOrDefault(Severity.Warning, []))
             .OrderBy(x => x.Location.SourceName)
-            .ThenBy(x => x.Location.Start)
-            .ThenBy(x => x.Location.Length);
+            .ThenBy(x => x.Location.Span.Start)
+            .ThenBy(x => x.Location.Span.Length);
 
         var statusText = DisplayBuildStatusText(collectedDiagnostics);
         var diagnosticsGrid = DisplayDiagnosticsGrid(source, diagnostics);
@@ -107,8 +107,8 @@ public abstract class CommandBase(IAnsiConsole console)
     private static Markup DisplayDiagnostic(LineMap lineMap, IDiagnostic diagnostic)
     {
         var location = diagnostic.Location;
-        var start = lineMap.GetCharacterPosition(location.Start);
-        var end = lineMap.GetCharacterPosition(location.End);
+        var start = lineMap.GetCharacterPosition(location.Span.Start);
+        var end = lineMap.GetCharacterPosition(location.Span.End);
         
         var color = diagnostic.Severity switch
         {

--- a/src/compiler/FlowAnalysis/FlowAnalyzer.cs
+++ b/src/compiler/FlowAnalysis/FlowAnalyzer.cs
@@ -119,7 +119,8 @@ file sealed class FlowVisitor(CancellationToken cancellationToken) : Visitor
         else
         {
             node.Function = null;
-            Diagnostics.Add(FlowDiagnostics.ReturnOutsideFunction.Format(node.ReturnKeyword.Location));
+            var location = new Location(node.Ast.Source.Name, node.ReturnKeyword.Span);
+            Diagnostics.Add(FlowDiagnostics.ReturnOutsideFunction.Format(location));
         }
 
         if (node.Expression is not null) Visit(node.Expression);
@@ -134,7 +135,8 @@ file sealed class FlowVisitor(CancellationToken cancellationToken) : Visitor
         else
         {
             node.Loop = null;
-            Diagnostics.Add(FlowDiagnostics.BreakOutsideFunction.Format(node.BreakKeyword.Location));
+            var location = new Location(node.Ast.Source.Name, node.BreakKeyword.Span);
+            Diagnostics.Add(FlowDiagnostics.BreakOutsideFunction.Format(location));
         }
 
         if (node.Expression is not null) Visit(node.Expression);

--- a/src/compiler/Location.cs
+++ b/src/compiler/Location.cs
@@ -4,30 +4,17 @@ namespace Noa.Compiler;
 /// A location in source code.
 /// </summary>
 /// <param name="SourceName">The name of the source.</param>
-/// <param name="Start">The start position in the source.</param>
-/// <param name="End">The end position in the source.</param>
-public readonly record struct Location(string SourceName, int Start, int End)
+/// <param name="Span">The text span of the location within the source.</param>
+public readonly record struct Location(string SourceName, TextSpan Span)
 {
     /// <summary>
-    /// The length of the location in the source.
-    /// </summary>
-    public int Length => End - Start;
-
-    /// <summary>
-    /// Creates a new location from a start position and length.
+    /// Creates a new location.
     /// </summary>
     /// <param name="sourceName">The name of the source.</param>
-    /// <param name="start">The start position in the source.</param>
-    /// <param name="length">The length of the location in source.</param>
-    public static Location FromLength(string sourceName, int start, int length) =>
-        new(sourceName, start, start + length);
-
-    /// <summary>
-    /// Returns whether a position is within the location.
-    /// </summary>
-    /// <param name="position">The position to check.</param>
-    public bool Contains(int position) =>
-        position >= Start && position < End;
-
-    public override string ToString() => $"{Start} to {End} in '{SourceName}'";
+    /// <param name="start">The start of the location from the start of the text.</param>
+    /// <param name="end">The end of the location from the start of the text.</param>
+    public Location(string sourceName, int start, int end)
+        : this(sourceName, new(start, end)) {}
+    
+    public override string ToString() => $"{Span} in '{SourceName}'";
 }

--- a/src/compiler/Nodes/NodeUtility.cs
+++ b/src/compiler/Nodes/NodeUtility.cs
@@ -88,12 +88,12 @@ public static class NodeUtility
     public static Node? FindNodeAt(this Node node, int position)
     {
         // This node doesn't contain the position.
-        if (!node.Location.Contains(position)) return null;
+        if (!node.Span.Contains(position)) return null;
 
         foreach (var child in node.Children)
         {
             // If the child contains the position, search the child.
-            if (child.Location.Contains(position)) return child.FindNodeAt(position);
+            if (child.Span.Contains(position)) return child.FindNodeAt(position);
         }
 
         // If no child contains the position, it must be in this node.

--- a/src/compiler/Nodes/Nodes.cs
+++ b/src/compiler/Nodes/Nodes.cs
@@ -20,9 +20,14 @@ public abstract class Node
     public Semantic<Node> Parent => Ast.GetParent(this)!;
     
     /// <summary>
+    /// The span of the node within the text.
+    /// </summary>
+    public required TextSpan Span { get; init; }
+
+    /// <summary>
     /// The source location of the node.
     /// </summary>
-    public required Location Location { get; init; }
+    public Location Location => new(Ast.Source.Name, Span);
     
     /// <summary>
     /// The child nodes of the node.

--- a/src/compiler/Nodes/Token.cs
+++ b/src/compiler/Nodes/Token.cs
@@ -9,15 +9,15 @@ namespace Noa.Compiler.Nodes;
 /// If not specified, <see cref="TokenKindExtensions.ConstantString"/> will be used,
 /// or an expect will be thrown if the kind does not have a constant string.
 /// </param>
-/// <param name="Location">The location of the token in source.</param>
-public readonly record struct Token(TokenKind Kind, string? Text, Location Location)
+/// <param name="Span">The span of the token within its text.</param>
+public readonly record struct Token(TokenKind Kind, string? Text, TextSpan Span)
 {
     public string Text { get; } =
         Text ?? Kind.ConstantString() ?? throw new InvalidOperationException(
             $"Cannot create a token with kind '{Kind}' without explicitly " +
             $"specifying its text because the kind does not have a constant string");
 
-    public override string ToString() => $"{Kind} '{Text}' at {Location}";
+    public override string ToString() => $"{Kind} '{Text}' at {Span}";
 }
 
 /// <summary>

--- a/src/compiler/Parsing/Blocks.cs
+++ b/src/compiler/Parsing/Blocks.cs
@@ -21,7 +21,7 @@ internal sealed partial class Parser
             if (statementOrExpression is not var (statement, expression))
             {
                 // An unexpected token was encountered.
-                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, Current.Location);
+                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, new(Source.Name, Current.Span));
                 ReportDiagnostic(diagnostic);
                 
                 // Try synchronize with the next statement or closing brace.
@@ -60,7 +60,7 @@ internal sealed partial class Parser
 
                 // If the current token is not a closing brace, then there's an unexpected token here.
 
-                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, Current.Location);
+                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, new(Source.Name, Current.Span));
                 ReportDiagnostic(diagnostic);
 
                 // Try synchronize with the next statement or closing brace.
@@ -98,12 +98,10 @@ internal sealed partial class Parser
                 ? null as Token?
                 : Expect(TokenKind.Semicolon);
 
-            var end = semicolon?.Location.End ?? expression.Location.End;
-
             statements.Add(new ExpressionStatement()
             {
                 Ast = Ast,
-                Location = new(Source.Name, expression.Location.Start, end),
+                Span = expression.Span with { End = semicolon?.Span.End ?? expression.Span.End },
                 Expression = expression
             });
         }
@@ -158,7 +156,7 @@ internal sealed partial class Parser
         return new AssignmentStatement()
         {
             Ast = Ast,
-            Location = new(Source.Name, target.Location.Start, value.Location.End),
+            Span = TextSpan.Between(target.Span, value.Span),
             Target = target,
             Value = value,
         };

--- a/src/compiler/Parsing/Blocks.cs
+++ b/src/compiler/Parsing/Blocks.cs
@@ -21,8 +21,7 @@ internal sealed partial class Parser
             if (statementOrExpression is not var (statement, expression))
             {
                 // An unexpected token was encountered.
-                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, new(Source.Name, Current.Span));
-                ReportDiagnostic(diagnostic);
+                ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
                 
                 // Try synchronize with the next statement or closing brace.
                 Synchronize(synchronizationTokens);
@@ -60,8 +59,7 @@ internal sealed partial class Parser
 
                 // If the current token is not a closing brace, then there's an unexpected token here.
 
-                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, new(Source.Name, Current.Span));
-                ReportDiagnostic(diagnostic);
+                ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
 
                 // Try synchronize with the next statement or closing brace.
                 Synchronize(synchronizationTokens);
@@ -89,8 +87,7 @@ internal sealed partial class Parser
 
             if (!expression.IsExpressionStatement())
             {
-                var diagnostic = ParseDiagnostics.InvalidExpressionStatement.Format(expression.Location);
-                ReportDiagnostic(diagnostic);
+                ReportDiagnostic(ParseDiagnostics.InvalidExpressionStatement, expression.Span);
             }
             
             // If the expression is a control flow expression statement then we don't expect a semicolon.
@@ -149,8 +146,7 @@ internal sealed partial class Parser
 
         if (!target.IsValidLValue())
         {
-            var diagnostic = ParseDiagnostics.InvalidLValue.Format(target.Location);
-            ReportDiagnostic(diagnostic);
+            ReportDiagnostic(ParseDiagnostics.InvalidLValue, target.Span);
         }
 
         return new AssignmentStatement()

--- a/src/compiler/Parsing/Expressions.cs
+++ b/src/compiler/Parsing/Expressions.cs
@@ -240,8 +240,7 @@ internal sealed partial class Parser
                     };
                 }
 
-                var diagnostic = ParseDiagnostics.LiteralTooLarge.Format(number.Text, new(Source.Name, number.Span));
-                ReportDiagnostic(diagnostic);
+                ReportDiagnostic(ParseDiagnostics.LiteralTooLarge, number.Text, number.Span);
                     
                 return new ErrorExpression()
                 {
@@ -303,7 +302,7 @@ internal sealed partial class Parser
                     // report an additional little informational error.
                     if (Current.Kind is not TokenKind.Else && ctx is FlowControlExpressionContext.Expression)
                     {
-                        ReportDiagnostic(ParseDiagnostics.ElseOmitted.Format(new(Source.Name, @if.Span)));
+                        ReportDiagnostic(ParseDiagnostics.ElseOmitted, @if.Span);
                     }
                     
                     var @else = Expect(TokenKind.Else);

--- a/src/compiler/Parsing/Expressions.cs
+++ b/src/compiler/Parsing/Expressions.cs
@@ -29,7 +29,7 @@ internal sealed partial class Parser
             return new UnaryExpression()
             {
                 Ast = parser.Ast,
-                Location = new(parser.Source.Name, kindToken.Location.Start, operand.Location.End),
+                Span = TextSpan.Between(kindToken.Span, operand.Span),
                 Kind = kind,
                 Operand = operand
             };
@@ -60,7 +60,7 @@ internal sealed partial class Parser
                 result = new BinaryExpression()
                 {
                     Ast = parser.Ast,
-                    Location = new(parser.Source.Name, result.Location.Start, right.Location.End),
+                    Span = TextSpan.Between(result.Span, right.Span),
                     Left = result,
                     Kind = kind,
                     Right = right
@@ -93,7 +93,7 @@ internal sealed partial class Parser
             return new BinaryExpression()
             {
                 Ast = parser.Ast,
-                Location = new(parser.Source.Name, result.Location.Start, right.Location.End),
+                Span = TextSpan.Between(result.Span, right.Span),
                 Left = result,
                 Kind = kind,
                 Right = right
@@ -142,7 +142,7 @@ internal sealed partial class Parser
             expression = new CallExpression()
             {
                 Ast = Ast,
-                Location = new(Source.Name, expression.Location.Start, closeParen.Location.End),
+                Span = TextSpan.Between(expression.Span, closeParen.Span),
                 Target = expression,
                 Arguments = arguments
             };
@@ -170,9 +170,7 @@ internal sealed partial class Parser
                 return new ReturnExpression()
                 {
                     Ast = Ast,
-                    Location = expression is not null
-                        ? new Location(Source.Name, @return.Location.Start, expression.Location.End)
-                        : @return.Location,
+                    Span = TextSpan.Between(@return.Span, expression?.Span),
                     ReturnKeyword = @return,
                     Expression = expression
                 };
@@ -187,9 +185,7 @@ internal sealed partial class Parser
                 return new BreakExpression()
                 {
                     Ast = Ast,
-                    Location = expression is not null
-                        ? new Location(Source.Name, @break.Location.Start, expression.Location.End)
-                        : @break.Location,
+                    Span = TextSpan.Between(@break.Span, expression?.Span),
                     BreakKeyword = @break,
                     Expression = expression
                 };
@@ -202,7 +198,7 @@ internal sealed partial class Parser
                 return new ContinueExpression()
                 {
                     Ast = Ast,
-                    Location = @continue.Location
+                    Span = @continue.Span
                 };
             }
 
@@ -213,7 +209,7 @@ internal sealed partial class Parser
                 return new IdentifierExpression()
                 {
                     Ast = Ast,
-                    Location = identifier.Location,
+                    Span = identifier.Span,
                     Identifier = identifier.Text
                 };
             }
@@ -225,7 +221,7 @@ internal sealed partial class Parser
                 return new BoolExpression()
                 {
                     Ast = Ast,
-                    Location = @bool.Location,
+                    Span = @bool.Span,
                     Value = @bool.Kind is TokenKind.True
                 };
             }
@@ -239,18 +235,18 @@ internal sealed partial class Parser
                     return new NumberExpression()
                     {
                         Ast = Ast,
-                        Location = number.Location,
+                        Span = number.Span,
                         Value = value
                     };
                 }
 
-                var diagnostic = ParseDiagnostics.LiteralTooLarge.Format(number.Text, number.Location);
+                var diagnostic = ParseDiagnostics.LiteralTooLarge.Format(number.Text, new(Source.Name, number.Span));
                 ReportDiagnostic(diagnostic);
                     
                 return new ErrorExpression()
                 {
                     Ast = Ast,
-                    Location = number.Location
+                    Span = number.Span
                 };
             }
         
@@ -258,7 +254,7 @@ internal sealed partial class Parser
             return new ErrorExpression()
             {
                 Ast = Ast,
-                Location = Location.FromLength(Source.Name, Current.Location.Start, 0)
+                Span = TextSpan.FromLength(Current.Span.Start, 0)
             };
         }
     }
@@ -277,7 +273,7 @@ internal sealed partial class Parser
         return new()
         {
             Ast = Ast,
-            Location = new(Source.Name, openBrace.Location.Start, closeBrace.Location.End),
+            Span = TextSpan.Between(openBrace.Span, closeBrace.Span),
             Statements = statements,
             TrailingExpression = trailingExpression
         };
@@ -307,7 +303,7 @@ internal sealed partial class Parser
                     // report an additional little informational error.
                     if (Current.Kind is not TokenKind.Else && ctx is FlowControlExpressionContext.Expression)
                     {
-                        ReportDiagnostic(ParseDiagnostics.ElseOmitted.Format(@if.Location));
+                        ReportDiagnostic(ParseDiagnostics.ElseOmitted.Format(new(Source.Name, @if.Span)));
                     }
                     
                     var @else = Expect(TokenKind.Else);
@@ -317,7 +313,7 @@ internal sealed partial class Parser
                     elseClause = new()
                     {
                         Ast = Ast,
-                        Location = new(Source.Name, @else.Location.Start, ifFalse.Location.End),
+                        Span = TextSpan.Between(@else.Span, ifFalse.Span),
                         ElseKeyword = @else,
                         IfFalse = ifFalse
                     };
@@ -326,10 +322,7 @@ internal sealed partial class Parser
                 return new IfExpression()
                 {
                     Ast = Ast,
-                    Location = new(
-                        Source.Name,
-                        @if.Location.Start,
-                        elseClause?.Location.End ?? ifTrue.Location.End),
+                    Span = @if.Span with { End = elseClause?.Span.End ?? ifTrue.Span.End },
                     IfKeyword = @if,
                     Condition = condition,
                     IfTrue = ifTrue,
@@ -346,7 +339,7 @@ internal sealed partial class Parser
                 return new LoopExpression()
                 {
                     Ast = Ast,
-                    Location = new(Source.Name, loop.Location.Start, block.Location.End),
+                    Span = TextSpan.Between(loop.Span, block.Span),
                     LoopKeyword = loop,
                     Block = block
                 };

--- a/src/compiler/Parsing/Lexer.cs
+++ b/src/compiler/Parsing/Lexer.cs
@@ -66,14 +66,14 @@ internal sealed partial class Lexer
             }
 
             // Unknown
-            var unexpectedLocation = Location.FromLength(source.Name, position, 1);
-            var unexpectedToken = new Token(TokenKind.Error, Rest[..1].ToString(), unexpectedLocation);
-            diagnostics.Add(ParseDiagnostics.UnexpectedToken.Format(unexpectedToken, unexpectedLocation));
+            var unexpectedSpan = TextSpan.FromLength(position, 1);
+            var unexpectedToken = new Token(TokenKind.Error, Rest[..1].ToString(), unexpectedSpan);
+            diagnostics.Add(ParseDiagnostics.UnexpectedToken.Format(unexpectedToken, new(source.Name, unexpectedSpan)));
             Progress(1);
         }
         
-        var endLocation = Location.FromLength(source.Name, source.Text.Length, 0);
-        AddToken(new(TokenKind.EndOfFile, null, endLocation));
+        var endSpan = TextSpan.FromLength(source.Text.Length, 0);
+        AddToken(new(TokenKind.EndOfFile, null, endSpan));
     }
 
     private (TokenKind, int)? TrySymbol()

--- a/src/compiler/Parsing/LexerCore.cs
+++ b/src/compiler/Parsing/LexerCore.cs
@@ -33,12 +33,12 @@ internal sealed partial class Lexer(Source source, CancellationToken cancellatio
 
     private void ConstructToken(TokenKind kind, int length)
     {
-        var location = Location.FromLength(source.Name, position, length);
+        var span = TextSpan.FromLength(position, length);
         var text = kind.ConstantString() ?? Rest[..length].ToString();
         
         Progress(length);
 
-        AddToken(new(kind, text, location));
+        AddToken(new(kind, text, span));
     }
 
     private void AddToken(Token token) => tokens.Add(token);

--- a/src/compiler/Parsing/ParenthesizedExpression.cs
+++ b/src/compiler/Parsing/ParenthesizedExpression.cs
@@ -59,8 +59,7 @@ internal sealed partial class Parser
             if (Current.Kind is not TokenKind.Name)
             {
                 // An unexpected token was encountered.
-                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, new(Source.Name, Current.Span));
-                ReportDiagnostic(diagnostic);
+                ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
             
                 // Try synchronize with the next parameter.
                 Synchronize(SyntaxFacts.LambdaParameterListSynchronize);
@@ -143,7 +142,7 @@ internal sealed partial class Parser
         };
         
         // Todo: this should probably be moved to a standalone analyzer since it doesn't really belong in the parser.
-        ReportDiagnostic(MiscellaneousDiagnostics.TuplesUnsupported.Format(tuple.Location));
+        ReportDiagnostic(MiscellaneousDiagnostics.TuplesUnsupported, tuple.Span);
 
         return tuple;
     }

--- a/src/compiler/Parsing/Parser.cs
+++ b/src/compiler/Parsing/Parser.cs
@@ -38,15 +38,14 @@ internal sealed partial class Parser
 
         var endOfFile = Expect(TokenKind.EndOfFile);
 
-        var start = statements.FirstOrDefault()?.Location.Start
-                    ?? trailingExpression?.Location.Start
-                    ?? endOfFile.Location.Start;
-        var location = new Location(Source.Name, start, endOfFile.Location.End);
+        var start = statements.FirstOrDefault()?.Span.Start
+                    ?? trailingExpression?.Span.Start
+                    ?? endOfFile.Span.Start;
 
         return new()
         {
             Ast = Ast,
-            Location = location,
+            Span = endOfFile.Span with { Start = start },
             Statements = statements,
             TrailingExpression = trailingExpression
         };
@@ -59,7 +58,7 @@ internal sealed partial class Parser
         return new()
         {
             Ast = Ast,
-            Location = name.Location,
+            Span = name.Span,
             Name = name.Text
         };
     }
@@ -110,8 +109,8 @@ internal sealed partial class Parser
 
         var end = (expressionBody, blockBody) switch
         {
-            (var (_, semicolon), null) => semicolon.Location.End,
-            (null, not null) => blockBody.Location.End,
+            (var (_, semicolon), null) => semicolon.Span.End,
+            (null, not null) => blockBody.Span.End,
             // It's impossible for the expression body and block body to both be null or both not be null.
             _ => throw new UnreachableException()
         };
@@ -119,7 +118,7 @@ internal sealed partial class Parser
         return new()
         {
             Ast = Ast,
-            Location = new(Source.Name, func.Location.Start, end),
+            Span = func.Span with { End = end },
             FuncKeyword = func,
             Identifier = identifier,
             Parameters = parameters,
@@ -136,12 +135,12 @@ internal sealed partial class Parser
 
         var identifier = ParseIdentifier();
 
-        var start = mutToken?.Location.Start ?? identifier.Location.Start;
+        var start = mutToken?.Span.Start ?? identifier.Span.Start;
         
         return new()
         {
             Ast = Ast,
-            Location = new(Source.Name, start, identifier.Location.End),
+            Span = identifier.Span with { Start = start },
             IsMutable = mutToken is not null,
             Identifier = identifier
         };
@@ -170,7 +169,7 @@ internal sealed partial class Parser
         return new()
         {
             Ast = Ast,
-            Location = new(Source.Name, let.Location.Start, semicolon.Location.End),
+            Span = TextSpan.Between(let.Span, semicolon.Span),
             LetKeyword = let,
             IsMutable = isMutable,
             Identifier = identifier,

--- a/src/compiler/Parsing/ParserCore.cs
+++ b/src/compiler/Parsing/ParserCore.cs
@@ -10,8 +10,6 @@ internal sealed partial class Parser
 
     internal IReadOnlyCollection<IDiagnostic> Diagnostics => state.Diagnostics;
     
-    private Source Source => state.Source;
-    
     private Ast Ast => state.Ast;
 
     private Token Current => state.Current;
@@ -30,7 +28,7 @@ internal sealed partial class Parser
 
     private void ReportDiagnostic(DiagnosticTemplate template, TextSpan span)
     {
-        var location = new Location(Source.Name, span);
+        var location = new Location(state.Source.Name, span);
         var diagnostic = template.Format(location);
         state.Diagnostics.Add(diagnostic);
     }
@@ -40,7 +38,7 @@ internal sealed partial class Parser
 
     private void ReportDiagnostic<T>(DiagnosticTemplate<T> template, T arg, TextSpan span)
     {
-        var location = new Location(Source.Name, span);
+        var location = new Location(state.Source.Name, span);
         var diagnostic = template.Format(arg, location);
         state.Diagnostics.Add(diagnostic);
     }

--- a/src/compiler/Parsing/ParserCore.cs
+++ b/src/compiler/Parsing/ParserCore.cs
@@ -37,18 +37,18 @@ internal sealed partial class Parser
     {
         if (Current.Kind == kind) return Advance();
 
-        var diagnostic = ParseDiagnostics.ExpectedKinds.Format([kind], Current.Location);
+        var diagnostic = ParseDiagnostics.ExpectedKinds.Format([kind], new(Source.Name, Current.Span));
         ReportDiagnostic(diagnostic);
         
-        var location = Location.FromLength(Source.Name, Current.Location.Start, 0);
-        return new(TokenKind.Error, "", location);
+        var span = TextSpan.FromLength(Current.Span.Start, 0);
+        return new(TokenKind.Error, "", span);
     }
 
     private Token? Expect(IReadOnlySet<TokenKind> kinds)
     {
         if (kinds.Contains(Current.Kind)) return Current;
 
-        var diagnostic = ParseDiagnostics.ExpectedKinds.Format(kinds, Current.Location);
+        var diagnostic = ParseDiagnostics.ExpectedKinds.Format(kinds, new(Source.Name, Current.Span));
         ReportDiagnostic(diagnostic);
         
         return null;
@@ -99,7 +99,7 @@ internal sealed partial class Parser
             // Check whether the parser parsed anything at all to prevent it from getting stuck.
             if (Current == previousToken)
             {
-                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, Current.Location);
+                var diagnostic = ParseDiagnostics.UnexpectedToken.Format(Current, new(Source.Name, Current.Span));
                 ReportDiagnostic(diagnostic);
 
                 Advance();

--- a/src/compiler/TextSpan.cs
+++ b/src/compiler/TextSpan.cs
@@ -1,0 +1,51 @@
+namespace Noa.Compiler;
+
+/// <summary>
+/// A span of characters within a text.
+/// </summary>
+/// <param name="Start">The start of the span from the start of the text.</param>
+/// <param name="End">The end of the span from the start of the text.</param>
+public readonly record struct TextSpan(int Start, int End)
+{
+    /// <summary>
+    /// The length of the span within the text.
+    /// </summary>
+    public int Length => End - Start;
+
+    /// <summary>
+    /// Creates a new span from a start position and a length.
+    /// </summary>
+    /// <param name="start">The start of the span from the start of the text.</param>
+    /// <param name="length">The length of the span within the text.</param>
+    public static TextSpan FromLength(int start, int length) =>
+        new(start, start + length);
+
+    /// <summary>
+    /// Creates a new span from the total span of two other spans.
+    /// The spans do not have to be connected or next to each other.
+    /// </summary>
+    /// <param name="a">The first span.</param>
+    /// <param name="b">The second span.</param>
+    /// <returns>
+    /// The span between <paramref name="a"/> and <paramref name="b"/>.
+    /// </returns>
+    public static TextSpan Between(TextSpan a, TextSpan b) =>
+        new(int.Min(a.Start, b.Start), int.Max(a.End, b.End));
+
+    /// <inheritdoc cref="Between(TextSpan, TextSpan)"/>
+    /// <returns>
+    /// The span between <paramref name="a"/> and <paramref name="b"/>,
+    /// or <paramref name="a"/> if <paramref name="b"/> is <see langword="null"/>.
+    /// </returns>
+    public static TextSpan Between(TextSpan a, TextSpan? b) =>
+        b is { } bx ? Between(a, bx) : a;
+
+    /// <summary>
+    /// Return whether a position is within the span.
+    /// </summary>
+    /// <param name="position">The position to check.</param>
+    public bool Contains(int position) =>
+        position >= Start && position < End;
+
+    public override string ToString() => $"{Start} to {End}";
+}

--- a/src/lang-server/Features/Diagnostics.cs
+++ b/src/lang-server/Features/Diagnostics.cs
@@ -45,7 +45,7 @@ public sealed partial class NoaLanguageServer : IDiagnostics
         return new()
         {
             Message = message,
-            Range = ToRange(location, document),
+            Range = ToLspRange(location.Span, document),
             Code = new OneOf<int, string>(diagnostic.Id.ToString()),
             Severity = diagnostic.Severity switch
             {

--- a/src/lang-server/Features/Rename.cs
+++ b/src/lang-server/Features/Rename.cs
@@ -28,7 +28,7 @@ public sealed partial class NoaLanguageServer : IRename, IPrepareRename
 
         if (symbol is not IDeclaredSymbol declared) return Task.FromResult<OneOf<Range, PrepareRenameResult>?>(null);
 
-        var range = ToRange(declared.DefinitionLocation, document);
+        var range = ToLspRange(declared.DefinitionLocation.Span, document);
 
         return Task.FromResult(new OneOf<Range, PrepareRenameResult>?(range));
     }
@@ -54,7 +54,7 @@ public sealed partial class NoaLanguageServer : IRename, IPrepareRename
 
         var textEdits = references.Select(x => new TextEdit()
         {
-            Range = ToRange(x, document),
+            Range = ToLspRange(x.Span, document),
             NewText = param.NewName
         });
         var textDocumentEdit = new TextDocumentEdit()

--- a/src/lang-server/NoaLanguageServer.cs
+++ b/src/lang-server/NoaLanguageServer.cs
@@ -106,19 +106,19 @@ public sealed partial class NoaLanguageServer(
     private static Location ToLspLocation(Noa.Compiler.Location location, NoaDocument document) =>
         new()
         {
-            Range = ToRange(location, document),
+            Range = ToLspRange(location.Span, document),
             Uri = document.Uri
         };
 
     /// <summary>
-    /// Converts a <see cref="Noa.Compiler.Location"/> into a <see cref="Range"/>.
+    /// Converts a <see cref="TextSpan"/> into a <see cref="Range"/>.
     /// </summary>
-    /// <param name="location">The location to convert.</param>
+    /// <param name="span">The span to convert.</param>
     /// <param name="document">The document the location is from.</param>
-    private static Range ToRange(Noa.Compiler.Location location, NoaDocument document)
+    private static Range ToLspRange(TextSpan span, NoaDocument document)
     {
-        var start = document.LineMap.GetCharacterPosition(location.Start);
-        var end = document.LineMap.GetCharacterPosition(location.End);
+        var start = document.LineMap.GetCharacterPosition(span.Start);
+        var end = document.LineMap.GetCharacterPosition(span.End);
 
         return new()
         {


### PR DESCRIPTION
Add `TextSpan` as a representation of just a span of characters within some text. This is to separate locations (with a source name) and spans within text to make some things (mainly the LSP and character position lookups) independent from source names.