### PR TITLE
Add run code lens

### DIFF
--- a/src/lang-server/Addon/ICodeLens.cs
+++ b/src/lang-server/Addon/ICodeLens.cs
@@ -1,0 +1,19 @@
+using Draco.Lsp.Attributes;
+using Draco.Lsp.Model;
+
+namespace Noa.LangServer.Addon;
+
+[ClientCapability("TextDocument.CodeLens")]
+internal interface ICodeLens
+{
+    [ServerCapability(nameof(ServerCapabilities.CodeLensProvider))]
+    ICodeLensOptions Capability => CodeLensRegistrationOptions;
+
+    [Request("textDocument/codeLens")]
+    Task<IList<CodeLens>?> CodeLensAsync(
+        CodeLensParams param,
+        CancellationToken cancellationToken);
+    
+    [RegistrationOptions("textDocument/codeLens")]
+    CodeLensRegistrationOptions CodeLensRegistrationOptions { get; }
+}

--- a/src/lang-server/Features/CodeLens.cs
+++ b/src/lang-server/Features/CodeLens.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Draco.Lsp.Model;
+using Noa.LangServer.Addon;
+
+namespace Noa.LangServer;
+
+public sealed partial class NoaLanguageServer : ICodeLens
+{
+    public CodeLensRegistrationOptions CodeLensRegistrationOptions => new()
+    {
+        DocumentSelector = DocumentSelector,
+        ResolveProvider = false
+    };
+
+    public Task<IList<CodeLens>?> CodeLensAsync(CodeLensParams param, CancellationToken cancellationToken)
+    {
+        var documentUri = param.TextDocument.Uri;
+        logger.Debug("Fetching code lens for {documentUri}", documentUri);
+
+        var document = workspace.GetOrCreateDocument(documentUri, cancellationToken);
+
+        // Make the code lens always show on the very first line with anything actually on it.
+        var documentStart = document.Ast.Root.Span.Start;
+        var firstLineSpan = document.LineMap.GetCharacterPosition(documentStart).Line.Span;
+
+        var lens = new CodeLens()
+        {
+            Range = ToLspRange(firstLineSpan, document),
+            Command = new Command()
+            {
+                Title = "▶ Run",
+                Command_ = "noa-lang.run",
+                Arguments = []
+            }
+        };
+
+        return Task.FromResult<IList<CodeLens>?>([lens]);
+    }
+}

--- a/src/vscode-extension/package.json
+++ b/src/vscode-extension/package.json
@@ -58,6 +58,11 @@
                     "default": null,
                     "description": "A path to the executable for the Noa CLI. If not specified, invokes the default `noa` command. Requires restarting the extension to take effect."
                 },
+                "noa-lang.runtimeExecutable": {
+                    "type": "string",
+                    "default": null,
+                    "description": "A path to the executable for the Noa runtime. If not specified, uses the `NOA_RUNTIME` environment variable."
+                },
                 "noa-lang.serverLogPath": {
                     "type": "string",
                     "default": null,

--- a/src/vscode-extension/src/commands.ts
+++ b/src/vscode-extension/src/commands.ts
@@ -1,5 +1,6 @@
 import { window } from "vscode";
 import { restartLanguageServer } from "./lang_server";
+import { runDocument } from "./run";
 
 /**
  * Restarts the language server.
@@ -9,5 +10,20 @@ export async function restartLangServer() {
 
     if (!success) {
         window.showErrorMessage("Failed to restart the language server.");
+    }
+}
+
+/**
+ * Runs the currently opened document.
+ */
+export async function run() {
+    let editor = window.activeTextEditor;
+    
+    if (editor) {
+        await runDocument(editor.document);
+    } else {
+        window.showErrorMessage(
+            "Cannot run document because no editor is active."
+        );
     }
 }

--- a/src/vscode-extension/src/config.ts
+++ b/src/vscode-extension/src/config.ts
@@ -36,6 +36,17 @@ export function getLogLevel(): string {
 }
 
 /**
+ * Updates the runtime executable path configuration interactively.
+ * @returns The new value of the runtime executable, or undefined if canceled.
+ */
+export async function updateRuntimePathInteractively(): Promise<string | undefined> {
+    return await updateInteractively(
+        "runtimeExecutable",
+        "Enter the path to the Noa runtime executable"
+    );
+}
+
+/**
  * Interactively updates a configuration section.
  * @param section The the config section to update.
  * @param title The title input box.

--- a/src/vscode-extension/src/config.ts
+++ b/src/vscode-extension/src/config.ts
@@ -42,7 +42,23 @@ export function getLogLevel(): string {
 export async function updateRuntimePathInteractively(): Promise<string | undefined> {
     return await updateInteractively(
         "runtimeExecutable",
-        "Enter the path to the Noa runtime executable"
+        "Select Noa runtime executable",
+        "Select",
+        async (title, prompt) => {
+            let res = await window.showOpenDialog({
+                title,
+                openLabel: prompt,
+                canSelectFiles: true,
+                canSelectFolders: false,
+                canSelectMany: false
+            });
+
+            if (!res) {
+                return undefined;
+            }
+
+            return res[0].fsPath;
+        }
     );
 }
 
@@ -56,12 +72,12 @@ export async function updateRuntimePathInteractively(): Promise<string | undefin
 export async function updateInteractively(
     section: string,
     title?: string,
-    prompt?: string
+    prompt?: string,
+    inputFunc?: (title?: string, prompt?: string) => Thenable<string | undefined>
 ): Promise<string | undefined> {
-    let value = await window.showInputBox({
-        title,
-        prompt
-    });
+    inputFunc ??= async (title, prompt) => await window.showInputBox({ title, prompt });
+
+    let value = await inputFunc(title, prompt);
 
     if (!value) {
         return undefined;

--- a/src/vscode-extension/src/config.ts
+++ b/src/vscode-extension/src/config.ts
@@ -1,4 +1,4 @@
-import { WorkspaceConfiguration, workspace } from "vscode";
+import { ConfigurationTarget, WorkspaceConfiguration, window, workspace } from "vscode";
 
 /**
  * Gets the extension configuration.
@@ -26,4 +26,55 @@ export function getServerLogPath(): string | undefined {
  */
 export function getLogLevel(): string {
     return getConfig().get("logLevel") || "info";
+}
+
+/**
+ * Interactively updates a configuration section.
+ * @param section The the config section to update.
+ * @param title The title input box.
+ * @param prompt The input box prompt.
+ * @returns The new value of the configuration, or undefined if canceled.
+ */
+export async function updateInteractively(
+    section: string,
+    title?: string,
+    prompt?: string
+): Promise<string | undefined> {
+    let value = await window.showInputBox({
+        title,
+        prompt
+    });
+
+    if (!value) {
+        return undefined;
+    }
+
+    let target = await window.showQuickPick([
+        {
+            label: "Global",
+            description: "Set the configuration globally",
+            target: ConfigurationTarget.Global
+        },
+        {
+            label: "Workspace",
+            description: "Set the configuration in the workspace",
+            target: ConfigurationTarget.Workspace
+        },
+        {
+            label: "Workspace folder",
+            description: "Set the configuration in the workspace folder",
+            target: ConfigurationTarget.WorkspaceFolder
+        }
+    ], {
+        title: "Where should the configuration be set?",
+        canPickMany: false,
+    });
+
+    if (!target) {
+        return undefined;
+    }
+
+    await getConfig().update(section, value, target.target);
+
+    return value;
 }

--- a/src/vscode-extension/src/config.ts
+++ b/src/vscode-extension/src/config.ts
@@ -93,11 +93,6 @@ export async function updateInteractively(
             label: "Workspace",
             description: "Set the configuration in the workspace",
             target: ConfigurationTarget.Workspace
-        },
-        {
-            label: "Workspace folder",
-            description: "Set the configuration in the workspace folder",
-            target: ConfigurationTarget.WorkspaceFolder
         }
     ], {
         title: "Where should the configuration be set?",

--- a/src/vscode-extension/src/config.ts
+++ b/src/vscode-extension/src/config.ts
@@ -15,6 +15,13 @@ export function getCliCommand(): string {
 }
 
 /**
+ * Gets the runtime executable path used by the extension.
+ */
+export function getRuntimePath(): string | undefined {
+    return getConfig().get("runtimeExecutable");
+}
+
+/**
  * Gets the logging path used by the language server.
  */
 export function getServerLogPath(): string | undefined {

--- a/src/vscode-extension/src/extension.ts
+++ b/src/vscode-extension/src/extension.ts
@@ -3,8 +3,11 @@
 import { ExtensionContext, commands } from "vscode";
 import { restartLangServer } from "./commands";
 import { startLanguageServer, stopLanguageServer } from "./lang_server";
+import { initializeVariables } from "./variables";
 
 export async function activate(context: ExtensionContext) {
+    initializeVariables(context.environmentVariableCollection);
+
     context.subscriptions.push(commands.registerCommand("noa-lang.restartLangServer", restartLangServer));
 
     await startLanguageServer();

--- a/src/vscode-extension/src/extension.ts
+++ b/src/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { ExtensionContext, commands } from "vscode";
-import { restartLangServer } from "./commands";
+import { restartLangServer, run } from "./commands";
 import { startLanguageServer, stopLanguageServer } from "./lang_server";
 import { initializeVariables } from "./variables";
 
@@ -9,6 +9,7 @@ export async function activate(context: ExtensionContext) {
     initializeVariables(context.environmentVariableCollection);
 
     context.subscriptions.push(commands.registerCommand("noa-lang.restartLangServer", restartLangServer));
+    context.subscriptions.push(commands.registerCommand("noa-lang.run", run));
 
     await startLanguageServer();
 }

--- a/src/vscode-extension/src/run.ts
+++ b/src/vscode-extension/src/run.ts
@@ -1,0 +1,103 @@
+import { Terminal, TextDocument, ThemeIcon, Uri, window,  } from "vscode";
+import { checkForCli } from "./command_line";
+import { getCliCommand, getRuntimePath, updateRuntimePathInteractively } from "./config";
+import { getNoaRuntimeVariable } from "./variables";
+
+let terminal: Terminal | undefined = undefined;
+
+const terminalIcon: ThemeIcon = new ThemeIcon("notebook-execute");
+
+function getOrCreateTerminal(): Terminal {
+    terminal ??= window.createTerminal({
+        name: "Noa run",
+        iconPath: terminalIcon,
+        
+    });
+
+    return terminal;
+}
+
+async function userUpdateRuntimePath(): Promise<string | undefined> {
+    async function showError(): Promise<void> {
+        await window.showErrorMessage("No runtime executable has been configured.");
+    }
+
+    let response = await window.showWarningMessage(
+        "The environment `NOA_RUNTIME` is not set. Do you want to manually set the path to the Noa runtime executable?",
+        {
+            title: "Yes",
+            value: true
+        },
+        {
+            title: "No",
+            value: false
+        }
+    );
+
+    if (response === undefined || !response.value) {
+        await showError();
+        return undefined;
+    }
+
+    let configured = await updateRuntimePathInteractively();
+
+    if (configured === undefined) {
+        await showError();
+        return undefined;
+    }
+
+    return configured;
+}
+
+function constructRunCommand(document: TextDocument, runtimePath: string | undefined): string {
+    let args = [
+        "run",
+        document.uri.fsPath,
+        "--print-ret"
+    ];
+    
+    if (runtimePath !== undefined) {
+        args.push(`--runtime ${runtimePath}`);
+    }
+
+    let command = getCliCommand();
+
+    return `${command} ${args.join(" ")}`;
+}
+
+/**
+ * Runs a Noa document.
+ * @param document The document to run.
+ * @returns Whether the document was successfully run.
+ */
+export async function runDocument(document: TextDocument): Promise<boolean> {
+    if (!await checkForCli()) {
+        let command = getCliCommand();
+        await window.showErrorMessage(
+            `Cannot find the Noa CLI (${command})`
+        );
+
+        return false;
+    }
+
+    let runtimePath: string | undefined;
+
+    if (getNoaRuntimeVariable() !== undefined) {
+        runtimePath = undefined;
+    } else {
+        runtimePath = getRuntimePath();
+
+        if (runtimePath === undefined) {
+            runtimePath = await userUpdateRuntimePath();
+        }
+    }
+
+    let runCommand = constructRunCommand(document, runtimePath);
+
+    await document.save();
+
+    let terminal = getOrCreateTerminal();
+    terminal.show();
+
+    terminal.sendText(runCommand, true);
+}

--- a/src/vscode-extension/src/run.ts
+++ b/src/vscode-extension/src/run.ts
@@ -41,7 +41,7 @@ async function userUpdateRuntimePath(): Promise<string | undefined> {
 
     let configured = await updateRuntimePathInteractively();
 
-    if (configured === undefined) {
+    if (!configured) {
         await showError();
         return undefined;
     }
@@ -87,8 +87,12 @@ export async function runDocument(document: TextDocument): Promise<boolean> {
     } else {
         runtimePath = getRuntimePath();
 
-        if (runtimePath === undefined) {
+        if (!runtimePath) {
             runtimePath = await userUpdateRuntimePath();
+
+            if (!runtimePath) {
+                return false;
+            }
         }
     }
 

--- a/src/vscode-extension/src/variables.ts
+++ b/src/vscode-extension/src/variables.ts
@@ -1,0 +1,18 @@
+import { GlobalEnvironmentVariableCollection } from "vscode";
+
+let variables: GlobalEnvironmentVariableCollection;
+
+/**
+ * Initializes the environment variable support for the extension.
+ * @param vars The environment variable collection.
+ */
+export function initializeVariables(vars: GlobalEnvironmentVariableCollection) {
+    variables = vars;
+}
+
+/**
+ * Gets the `NOA_RUNTIME` environment variable.
+ */
+export function getNoaRuntimeVariable(): string | undefined {
+    return variables.get("NOA_RUNTIME")?.value;
+}


### PR DESCRIPTION
Implement code lens support in the language server, as well as a command in the VSCode extension to run a file. Fixes #56.