### PR TITLE
Add LookupLocation

### DIFF
--- a/src/compiler-tests/Symbols/SymbolResolutionTests.cs
+++ b/src/compiler-tests/Symbols/SymbolResolutionTests.cs
@@ -30,11 +30,11 @@ public class SymbolResolutionTests
 
         var scope = x1Decl.Scope.Value;
 
-        var x2Lookup = scope.LookupSymbol("x", x2Decl).ShouldNotBeNull();
+        var x2Lookup = scope.LookupSymbol("x", LookupLocation.AtNode(x2Decl)).ShouldNotBeNull();
         x2Lookup.Symbol.ShouldBe(x1);
         x2Lookup.Accessibility.ShouldBe(SymbolAccessibility.Accessible);
 
-        var endLookup = scope.LookupSymbol("x", null).ShouldNotBeNull();
+        var endLookup = scope.LookupSymbol("x", LookupLocation.AtEnd()).ShouldNotBeNull();
         endLookup.Symbol.ShouldBe(x2);
         endLookup.Accessibility.ShouldBe(SymbolAccessibility.Accessible);
     }
@@ -58,18 +58,18 @@ public class SymbolResolutionTests
 
         var scope = ast.Root.Block.Statements[0].Scope.Value;
 
-        var xLookup = scope.LookupSymbol("x", null).ShouldNotBeNull();
+        var xLookup = scope.LookupSymbol("x", LookupLocation.AtEnd()).ShouldNotBeNull();
         xLookup.Symbol.ShouldBe(x);
         xLookup.Accessibility.ShouldBe(SymbolAccessibility.Accessible);
         
-        var yLookup = scope.LookupSymbol("y", null).ShouldNotBeNull();
+        var yLookup = scope.LookupSymbol("y", LookupLocation.AtEnd()).ShouldNotBeNull();
         yLookup.Symbol.ShouldBe(y);
         yLookup.Accessibility.ShouldBe(SymbolAccessibility.Accessible);
 
-        var declared = scope.DeclaredAt(null);
+        var declared = scope.DeclaredAt(LookupLocation.AtEnd());
         declared.ShouldBe([x, y], ignoreOrder: true);
         
-        var accessible = scope.AccessibleAt(null);
+        var accessible = scope.AccessibleAt(LookupLocation.AtEnd());
         accessible.ShouldBe([x, y], ignoreOrder: true);
     }
 
@@ -133,7 +133,7 @@ public class SymbolResolutionTests
 
         SymbolResolution.ResolveSymbols(ast);
         
-        var x = ast.TopLevelFunction.BodyScope.LookupSymbol("x", null)!.Value.Symbol;
+        var x = ast.TopLevelFunction.BodyScope.LookupSymbol("x", LookupLocation.AtEnd())!.Value.Symbol;
         
         var assignmentIdentifier = (IdentifierExpression)ast.Root.FindNodeAt(23)!;
         
@@ -157,10 +157,10 @@ public class SymbolResolutionTests
         
         var at = ast.Root.FindNodeAt(38)!;
         
-        var x = ast.TopLevelFunction.BodyScope.LookupSymbol("x", null)!.Value.Symbol;
-        var y = at.Scope.Value.LookupSymbol("y", null)!.Value.Symbol;
+        var x = ast.TopLevelFunction.BodyScope.LookupSymbol("x", LookupLocation.AtEnd())!.Value.Symbol;
+        var y = at.Scope.Value.LookupSymbol("y", LookupLocation.AtEnd())!.Value.Symbol;
         
-        at.Scope.Value.AccessibleAt(at).ShouldBe([x, y], ignoreOrder: true);
+        at.Scope.Value.AccessibleAt(LookupLocation.AtNode(at)).ShouldBe([x, y], ignoreOrder: true);
     }
     
     [Fact]

--- a/src/compiler/Services/LookupCorrection/LookupCorrectionService.cs
+++ b/src/compiler/Services/LookupCorrection/LookupCorrectionService.cs
@@ -1,7 +1,6 @@
 // ReSharper disable IdentifierTypo
 // ReSharper disable TooWideLocalVariableScope
 
-using Noa.Compiler.Nodes;
 using Noa.Compiler.Symbols;
 
 namespace Noa.Compiler.Services.LookupCorrection;
@@ -16,8 +15,8 @@ internal static class LookupCorrectionService
     /// <param name="name">The name which might have a typo.</param>
     /// <param name="scope">The scope to find correction symbols in.</param>
     /// <param name="at">The node at which to look up the correction symbols.</param>
-    public static IReadOnlyCollection<ISymbol> FindPossibleCorrections(string name, IScope scope, Node at) =>
-        scope.AccessibleAt(at)
+    public static IReadOnlyCollection<ISymbol> FindPossibleCorrections(string name, IScope scope, LookupLocation location) =>
+        scope.AccessibleAt(location)
             .Where(symbol => Distance(name, symbol.Name, MaxDistance + 1) <= MaxDistance)
             .ToArray();
 

--- a/src/compiler/Symbols/BlockScope.cs
+++ b/src/compiler/Symbols/BlockScope.cs
@@ -48,21 +48,15 @@ internal sealed class BlockScope(
     /// <summary>
     /// Tries to get the timeline index of a node.
     /// </summary>
-    /// <param name="node">
-    /// The node to look up the timeline index of,
-    /// or null to look up the timeline index for the end of the block.
-    /// </param>
-    /// <param name="parentLookupNode">
-    /// The node to look up the symbol at in the parent scope
-    /// if the requested symbol doesn't exist in the current scope.</param>
+    /// <param name="location">The location to look up the timeline index at.</param>
     /// <param name="timelineIndex">The timeline index for the node.</param>
     private bool TryGetTimelineIndex(
-        Node? node,
+        LookupLocation location,
         out int timelineIndex)
     {
-        if (node is null)
+        if (location.IsAtEnd)
         {
-            // If the node we're trying to get the timeline index for is null,
+            // If the lookup we're trying to get the timeline index for is null,
             // that means we want to get the timeline index and parent lookup node for the very end of the scope.
             timelineIndex = VariableTimeline.Count - 1;
             return true;
@@ -70,7 +64,7 @@ internal sealed class BlockScope(
 
         // If the node is a statement then we just use that.
         // Otherwise, we try to find the first statement-like node.
-        var statementLikeNode = node as Statement ?? FindRelevantStatementLikeAncestor(node);
+        var statementLikeNode = location.Node as Statement ?? FindRelevantStatementLikeAncestor(location.Node);
 
         if (statementLikeNode is null)
         {
@@ -89,7 +83,7 @@ internal sealed class BlockScope(
         return false;
     }
     
-    public LookupResult? LookupSymbol(string name, Node? at, Func<ISymbol, bool>? predicate = null)
+    public LookupResult? LookupSymbol(string name, LookupLocation location, Func<ISymbol, bool>? predicate = null)
     {
         // If there is a function with the name then we don't need to look up anything else.
         if (Functions.TryGetValue(name, out var function) &&
@@ -98,11 +92,11 @@ internal sealed class BlockScope(
             return new(function, SymbolAccessibility.Accessible);
         }
 
-        if (!TryGetTimelineIndex(at, out var timelineIndex))
+        if (!TryGetTimelineIndex(location, out var timelineIndex))
         {
-            // If we can't find the timeline index for the node we're looking up at, we're heading to
+            // If we can't find the timeline index for the location we're looking up at, we're heading to
             // the parent scope to check if it has a symbol available at the location of this block.
-            return Parent?.LookupSymbol(name, block, predicate);
+            return Parent?.LookupSymbol(name, LookupLocation.AtNode(block), predicate);
         }
 
         var variables = VariableTimeline[timelineIndex];
@@ -115,7 +109,7 @@ internal sealed class BlockScope(
         // We can't find the symbol in this scope.
 
         // Check if the symbol can be found in a parent scope.
-        if (Parent?.LookupSymbol(name, block, predicate) is { } parentLookup) return parentLookup;
+        if (Parent?.LookupSymbol(name, LookupLocation.AtNode(block), predicate) is { } parentLookup) return parentLookup;
         
         // We know at this point that the symbol is not accessible, but to provide better error reporting
         // we also check future points in the variable timeline to see if the symbol is accessible there.
@@ -132,9 +126,9 @@ internal sealed class BlockScope(
         return null;
     }
 
-    public IEnumerable<IDeclaredSymbol> DeclaredAt(Node? at)
+    public IEnumerable<IDeclaredSymbol> DeclaredAt(LookupLocation location)
     {
-        if (!TryGetTimelineIndex(at, out var timelineIndex)) return [];
+        if (!TryGetTimelineIndex(location, out var timelineIndex)) return [];
 
         var variables = VariableTimeline[timelineIndex];
 
@@ -142,16 +136,16 @@ internal sealed class BlockScope(
             .Concat((IEnumerable<IDeclaredSymbol>)variables.Values);
     }
 
-    public IEnumerable<ISymbol> AccessibleAt(Node? at)
+    public IEnumerable<ISymbol> AccessibleAt(LookupLocation location)
     {
-        if (!TryGetTimelineIndex(at, out var timelineIndex)) return [];
+        if (!TryGetTimelineIndex(location, out var timelineIndex)) return [];
 
         var variables = VariableTimeline[timelineIndex];
 
         var declared = Functions.Values
             .Concat((IEnumerable<IDeclaredSymbol>)variables.Values);
 
-        var parentAccessible = Parent?.AccessibleAt(block) ?? [];
+        var parentAccessible = Parent?.AccessibleAt(LookupLocation.AtNode(block)) ?? [];
 
         return declared.Concat(parentAccessible);
     }

--- a/src/compiler/Symbols/BlockingScope.cs
+++ b/src/compiler/Symbols/BlockingScope.cs
@@ -13,9 +13,9 @@ internal sealed class BlockingScope(IScope parent, Node declaration) : IScope
 
     // Blocking scopes do not declare symbols of their own, they only forward symbols from their parent scope.
     
-    public LookupResult? LookupSymbol(string name, Node? at, Func<ISymbol, bool>? predicate = null)
+    public LookupResult? LookupSymbol(string name, LookupLocation location, Func<ISymbol, bool>? predicate = null)
     {
-        if (Parent.LookupSymbol(name, declaration, predicate) is not { } lookup) return null;
+        if (Parent.LookupSymbol(name, LookupLocation.AtNode(declaration), predicate) is not { } lookup) return null;
 
         return lookup.Symbol switch
         {
@@ -24,8 +24,8 @@ internal sealed class BlockingScope(IScope parent, Node declaration) : IScope
         };
     }
     
-    public IEnumerable<IDeclaredSymbol> DeclaredAt(Node? at) => [];
+    public IEnumerable<IDeclaredSymbol> DeclaredAt(LookupLocation location) => [];
 
-    public IEnumerable<ISymbol> AccessibleAt(Node? at) =>
-        Parent.AccessibleAt(declaration);
+    public IEnumerable<ISymbol> AccessibleAt(LookupLocation location) =>
+        Parent.AccessibleAt(LookupLocation.AtNode(declaration));
 }

--- a/src/compiler/Symbols/MapScope.cs
+++ b/src/compiler/Symbols/MapScope.cs
@@ -17,16 +17,16 @@ internal sealed class MapScope(IScope? parent, Node declaration) : IScope
 
     // Lookup locations are irrelevant to map scopes because they're essentially just flat maps of symbols.
     
-    public LookupResult? LookupSymbol(string name, Node? at, Func<ISymbol, bool>? predicate = null) =>
+    public LookupResult? LookupSymbol(string name, LookupLocation location, Func<ISymbol, bool>? predicate = null) =>
         symbols.TryGetValue(name, out var symbol) && (predicate?.Invoke(symbol) ?? true)
             ? new(symbol, SymbolAccessibility.Accessible)
-            : Parent?.LookupSymbol(name, declaration, predicate);
+            : Parent?.LookupSymbol(name, LookupLocation.AtNode(declaration), predicate);
  
-    public IEnumerable<IDeclaredSymbol> DeclaredAt(Node? at) =>
+    public IEnumerable<IDeclaredSymbol> DeclaredAt(LookupLocation location) =>
         symbols.Values;
 
-    public IEnumerable<ISymbol> AccessibleAt(Node? at) =>
-        DeclaredAt(at).Concat(Parent?.AccessibleAt(declaration) ?? []);
+    public IEnumerable<ISymbol> AccessibleAt(LookupLocation location) =>
+        DeclaredAt(location).Concat(Parent?.AccessibleAt(LookupLocation.AtNode(declaration)) ?? []);
 
     /// <summary>
     /// Declares a symbol within the scope.

--- a/src/compiler/Symbols/Scope.cs
+++ b/src/compiler/Symbols/Scope.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Noa.Compiler.Nodes;
 
 namespace Noa.Compiler.Symbols;
@@ -16,9 +17,8 @@ public interface IScope
     /// Looks up a symbol with a specified name at a specific point in the scope.
     /// </summary>
     /// <param name="name">The name of the symbol to look up.</param>
-    /// <param name="at">
-    /// The node to look up the symbol at.
-    /// If not specified, will look up symbols at the end of the scope.
+    /// <param name="location">
+    /// The location to look up the symbol at.
     /// </param>
     /// <param name="predicate">
     /// A predicate which determines whether to return a given symbol with the specified name.
@@ -26,25 +26,53 @@ public interface IScope
     /// <returns>
     /// A result containing the symbol as well as its accessibility, or null if no symbol could not be found.
     /// </returns>
-    LookupResult? LookupSymbol(string name, Node? at, Func<ISymbol, bool>? predicate = null);
+    LookupResult? LookupSymbol(string name, LookupLocation location, Func<ISymbol, bool>? predicate = null);
 
     /// <summary>
     /// Gets the declared symbols within the scope at a specific point.
     /// </summary>
-    /// <param name="at">
-    /// The node at which to find the declared symbols.
-    /// If not specified, will get the declared symbols at the end of the scope.
+    /// <param name="location">
+    /// The location at which to find the declared symbols.
     /// </param>
-    IEnumerable<IDeclaredSymbol> DeclaredAt(Node? at);
+    IEnumerable<IDeclaredSymbol> DeclaredAt(LookupLocation location);
 
     /// <summary>
     /// Gets all accessible symbols at a specific point in the scope.
     /// </summary>
-    /// <param name="at">
-    /// The node at which to find the accessible symbols.
-    /// If not specified, will get the accessible symbols at the end of the scope.
+    /// <param name="location">
+    /// The location at which to find the declared symbols.
     /// </param>
-    IEnumerable<ISymbol> AccessibleAt(Node? at);
+    IEnumerable<ISymbol> AccessibleAt(LookupLocation location);
+}
+
+/// <summary>
+/// A location to look up a symbol at.
+/// </summary>
+public readonly struct LookupLocation
+{
+    /// <summary>
+    /// The node the lookup is at.
+    /// </summary>
+    public Node? Node { get; }
+
+    /// <summary>
+    /// Whether the lookup is at the end of its scope.
+    /// </summary>
+    [MemberNotNullWhen(false, nameof(Node))]
+    public bool IsAtEnd => Node is null;
+
+    private LookupLocation(Node? node) => Node = node;
+
+    /// <summary>
+    /// Creates a new lookup location at a specified node.
+    /// </summary>
+    /// <param name="node">The node to perform the lookup at.</param>
+    public static LookupLocation AtNode(Node node) => new(node);
+
+    /// <summary>
+    /// Creates a new lookup location at the end of a scope.
+    /// </summary>
+    public static LookupLocation AtEnd() => new();
 }
 
 /// <summary>

--- a/src/compiler/Symbols/SymbolDiagnostics.cs
+++ b/src/compiler/Symbols/SymbolDiagnostics.cs
@@ -41,13 +41,13 @@ internal static class SymbolDiagnostics
                 .Raw(" in the same scope."),
             Severity.Error);
     
-    public static DiagnosticTemplate<(string, IScope, Node)> SymbolCannotBeFound { get; } =
-        DiagnosticTemplate.Create<(string name, IScope scope, Node at)>(
+    public static DiagnosticTemplate<(string, IScope, LookupLocation)> SymbolCannotBeFound { get; } =
+        DiagnosticTemplate.Create<(string name, IScope scope, LookupLocation location)>(
             "NOA-SYM-004",
             (arg, page) =>
             {
-                var (name, scope, at) = arg;
-                var corrections = LookupCorrectionService.FindPossibleCorrections(name, scope, at);
+                var (name, scope, location) = arg;
+                var corrections = LookupCorrectionService.FindPossibleCorrections(name, scope, location);
 
                 page.Raw("Cannot find a symbol with the name ")
                     .Name(name)

--- a/src/compiler/Symbols/SymbolResolution.cs
+++ b/src/compiler/Symbols/SymbolResolution.cs
@@ -269,10 +269,11 @@ file sealed class SymbolVisitor(IScope globalScope, CancellationToken cancellati
     {
         var identifier = node.Identifier;
         
-        if (currentScope.LookupSymbol(identifier, node) is not var (symbol, accessibility))
+        var location = LookupLocation.AtNode(node);
+        if (currentScope.LookupSymbol(identifier, location) is not var (symbol, accessibility))
         {
             Diagnostics.Add(SymbolDiagnostics.SymbolCannotBeFound.Format(
-                (identifier, currentScope, node),
+                (identifier, currentScope, location),
                 node.Location));
 
             node.ReferencedSymbol = new ErrorSymbol();

--- a/src/lang-server/Features/Completion.cs
+++ b/src/lang-server/Features/Completion.cs
@@ -33,7 +33,7 @@ public sealed partial class NoaLanguageServer : ICodeCompletion
         }
         else
         {
-            symbolCompletions = node.Scope.Value.AccessibleAt(node)
+            symbolCompletions = node.Scope.Value.AccessibleAt(LookupLocation.AtNode(node))
                 .Select(x =>
                 {
                     var item = new CompletionItem()


### PR DESCRIPTION
Add `LookupLocation` to make looking up symbols more explicit instead of just passing nodes and `null`.