### PR TITLE
Implement parse diagnostics and restructure trivia

### DIFF
--- a/src/cli/Program.cs
+++ b/src/cli/Program.cs
@@ -1,15 +1,7 @@
 ﻿using Cocona;
 using Cocona.Lite;
 using Noa.Cli;
-using Noa.Compiler;
-using Noa.Compiler.Syntax;
 using Spectre.Console;
-
-var source = """
-mut 1
-""";
-var ast = Ast.Create(new Source(source, "uwu"));
-ast.SyntaxRoot.GetLeftTokenAt(4);
 
 var builder = CoconaLiteApp.CreateBuilder(args, options =>
 {

--- a/src/cli/Program.cs
+++ b/src/cli/Program.cs
@@ -1,7 +1,15 @@
 ﻿using Cocona;
 using Cocona.Lite;
 using Noa.Cli;
+using Noa.Compiler;
+using Noa.Compiler.Syntax;
 using Spectre.Console;
+
+var source = """
+mut 1
+""";
+var ast = Ast.Create(new Source(source, "uwu"));
+ast.SyntaxRoot.GetLeftTokenAt(4);
 
 var builder = CoconaLiteApp.CreateBuilder(args, options =>
 {

--- a/src/compiler-tests/Syntax/SyntaxNavigationTests.cs
+++ b/src/compiler-tests/Syntax/SyntaxNavigationTests.cs
@@ -1,6 +1,6 @@
 namespace Noa.Compiler.Syntax.Tests;
 
-public class SyntaxUtilitiesTests
+public class SyntaxNavigationTests
 {
     [Fact]
     public void GetFirstToken_ReturnsSelf_ForToken()

--- a/src/compiler/Ast.cs
+++ b/src/compiler/Ast.cs
@@ -85,6 +85,9 @@ public sealed class Ast
         var redRoot = (RootSyntax)greenRoot.ToRed(0, null!);
 
         var ast = new Ast(source, redRoot, cancellationToken);
+
+        var parseDiagnostics = CollectParseDiagnostics(source, redRoot);
+        ast.diagnostics.AddRange(parseDiagnostics);
         
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -99,6 +102,13 @@ public sealed class Ast
         ControlFlowMarker.Mark(ast, cancellationToken);
 
         return ast;
+    }
+
+    private static IEnumerable<IDiagnostic> CollectParseDiagnostics(Source source, SyntaxNode node)
+    {
+        var diags = node.GetDiagnostics(source);
+        var childDiags = node.Children.SelectMany(child => CollectParseDiagnostics(source, child));
+        return diags.Concat(childDiags);
     }
 
     /// <summary>

--- a/src/compiler/Diagnostics/PartialDiagnostic.cs
+++ b/src/compiler/Diagnostics/PartialDiagnostic.cs
@@ -29,6 +29,12 @@ public interface IPartialDiagnostic
     /// <param name="source">The source the diagnostic is located in.</param>
     /// <param name="fullPosition">The full position in the source text which the diagnostic is relative to.</param>
     IDiagnostic Format(Source source, int fullPosition);
+
+    /// <summary>
+    /// Returns the partial diagnostic with an offset added.
+    /// </summary>
+    /// <param name="offset">The offset to add.</param>
+    IPartialDiagnostic AddOffset(int offset);
 }
 
 /// <summary>
@@ -56,6 +62,9 @@ public sealed record class PartialDiagnostic(
             Template,
             new Location(source.Name, span));
     }
+
+    public IPartialDiagnostic AddOffset(int offset) =>
+        new PartialDiagnostic(Template, Offset + offset, Width);
 }
 
 /// <summary>
@@ -87,4 +96,7 @@ public sealed record class PartialDiagnostic<TArg>(
             Argument,
             new Location(source.Name, span));
     }
+
+    public IPartialDiagnostic AddOffset(int offset) =>
+        new PartialDiagnostic<TArg>(Template, Argument, Offset + offset, Width);
 }

--- a/src/compiler/Parsing/Blocks.cs
+++ b/src/compiler/Parsing/Blocks.cs
@@ -24,6 +24,7 @@ internal sealed partial class Parser
             {
                 // An unexpected token was encountered.
                 ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
+                ConsumeUnexpected();
                 
                 // Try synchronize with the next statement or closing brace.
                 Synchronize(synchronizationTokens);
@@ -62,6 +63,7 @@ internal sealed partial class Parser
                 // If the current token is not a closing brace, then there's an unexpected token here.
 
                 ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
+                ConsumeUnexpected();
 
                 // Try synchronize with the next statement or closing brace.
                 Synchronize(synchronizationTokens);

--- a/src/compiler/Parsing/LexerCore.cs
+++ b/src/compiler/Parsing/LexerCore.cs
@@ -12,7 +12,7 @@ internal sealed partial class Lexer(Source source, CancellationToken cancellatio
     private readonly List<ILexerDiagnostic> diagnosticsForNextToken = [];
     private readonly string text = source.Text;
     private int position = 0;
-    private int leadingTriviaLength = 0;
+    private readonly ImmutableArray<Trivia>.Builder trivia = ImmutableArray.CreateBuilder<Trivia>();
 
     private char Current =>
         position < text.Length
@@ -41,15 +41,11 @@ internal sealed partial class Lexer(Source source, CancellationToken cancellatio
     private void ReportDiagnostic<T>(DiagnosticTemplate<T> template, T arg, int width) =>
         diagnosticsForNextToken.Add(new LexerDiagnostic<T>(template, arg, position, width));
     
-    private string ConsumeLeadingTrivia()
+    private ImmutableArray<Trivia> ConsumeLeadingTrivia()
     {
-        var leadingTrivia = leadingTriviaLength > 0
-            ? text[(position - leadingTriviaLength)..position]
-            : "";
-
-        leadingTriviaLength = 0;
-
-        return leadingTrivia;
+        var built = trivia.ToImmutable();
+        trivia.Clear();
+        return built;
     }
 
     private void ConstructToken(TokenKind kind, int length)

--- a/src/compiler/Parsing/ParenthesizedExpression.cs
+++ b/src/compiler/Parsing/ParenthesizedExpression.cs
@@ -63,6 +63,7 @@ internal sealed partial class Parser
             {
                 // An unexpected token was encountered.
                 ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
+                ConsumeUnexpected();
             
                 // Try synchronize with the next parameter.
                 Synchronize(SyntaxFacts.LambdaParameterListSynchronize);

--- a/src/compiler/Parsing/ParserCore.cs
+++ b/src/compiler/Parsing/ParserCore.cs
@@ -50,7 +50,8 @@ internal sealed partial class Parser
 
         ReportDiagnostic(ParseDiagnostics.ExpectedKinds, [kind], Current);
         
-        return new(TokenKind.Error, "", "", 0);
+        var trivia = Current.ToTriviaFollowedByUnexpectedToken().ToImmutableArray();
+        return new(TokenKind.Error, "", trivia, 0);
     }
 
     private Token? Expect(IReadOnlySet<TokenKind> kinds)

--- a/src/compiler/Parsing/ParserCore.cs
+++ b/src/compiler/Parsing/ParserCore.cs
@@ -50,8 +50,7 @@ internal sealed partial class Parser
 
         ReportDiagnostic(ParseDiagnostics.ExpectedKinds, [kind], Current);
         
-        var trivia = Current.ToTriviaFollowedByUnexpectedToken().ToImmutableArray();
-        return new(TokenKind.Error, "", trivia, 0);
+        return new(TokenKind.Error, "", [], 0);
     }
 
     private Token? Expect(IReadOnlySet<TokenKind> kinds)
@@ -63,6 +62,12 @@ internal sealed partial class Parser
         return null;
     }
 
+    private void ConsumeUnexpected() =>
+        state.ConsumeAsTrivia(TriviaTokenKind.Unexpected);
+
+    private void ConsumeSkipped() =>
+        state.ConsumeAsTrivia(TriviaTokenKind.Skipped);
+
     /// <summary>
     /// Synchronizes the parser with a set of token kinds.
     /// </summary>
@@ -73,7 +78,7 @@ internal sealed partial class Parser
         {
             cancellationToken.ThrowIfCancellationRequested();
             
-            Advance();
+            ConsumeSkipped();
         }
     }
 
@@ -110,6 +115,7 @@ internal sealed partial class Parser
             if (Current == previousToken)
             {
                 ReportDiagnostic(ParseDiagnostics.UnexpectedToken, Current);
+                ConsumeUnexpected();
 
                 Advance();
             }

--- a/src/compiler/Parsing/TokenKindExtensions.cs
+++ b/src/compiler/Parsing/TokenKindExtensions.cs
@@ -117,4 +117,11 @@ internal static class TokenKindExtensions
         TokenKind.GreaterThanEquals => BinaryKind.GreaterThanOrEqual,
         _ => null
     };
+
+    /// <summary>
+    /// Whether the token is invisible, i.e. does not consist of any text.
+    /// This is only the case for <see cref="TokenKind.Error"/> and <see cref="TokenKind.EndOfFile"/>.
+    /// </summary>
+    public static bool IsInvisible(this TokenKind kind) =>
+        kind is TokenKind.Error or TokenKind.EndOfFile;
 }

--- a/src/compiler/Parsing/TriviaToken.cs
+++ b/src/compiler/Parsing/TriviaToken.cs
@@ -1,0 +1,19 @@
+using Noa.Compiler.Syntax.Green;
+
+namespace Noa.Compiler.Parsing;
+
+internal readonly record struct TriviaToken(Token Token, TriviaTokenKind Kind)
+{
+    public Token AttachTo(Token token) => Kind switch
+    {
+        TriviaTokenKind.Unexpected => token.AddTokenAsUnexpectedTrivia(Token),
+        TriviaTokenKind.Skipped => token.AddTokenAsSkippedTrivia(Token),
+        _ => throw new UnreachableException()
+    };
+}
+
+internal enum TriviaTokenKind
+{
+    Unexpected,
+    Skipped
+}

--- a/src/compiler/Syntax/Green/Token.cs
+++ b/src/compiler/Syntax/Green/Token.cs
@@ -20,5 +20,12 @@ internal sealed class Token(TokenKind kind, string? text, ImmutableArray<Trivia>
 
     public override Syntax.SyntaxNode ToRed(int position, Syntax.SyntaxNode parent) => new Syntax.Token(this, position, parent);
 
+    /// <summary>
+    /// Returns a sequence of the token's trivia
+    /// followed by an <see cref="UnexpectedTokenTrivia"/> constructed from the token.
+    /// </summary>
+    public IEnumerable<Trivia> ToTriviaFollowedByUnexpectedToken() =>
+        LeadingTrivia.Append(new UnexpectedTokenTrivia(this));
+
     public override string ToString() => Text;
 }

--- a/src/compiler/Syntax/Green/Token.cs
+++ b/src/compiler/Syntax/Green/Token.cs
@@ -2,9 +2,9 @@ using Noa.Compiler.Parsing;
 
 namespace Noa.Compiler.Syntax.Green;
 
-internal sealed class Token(TokenKind kind, string? text, string leadingTrivia, int width) : SyntaxNode
+internal sealed class Token(TokenKind kind, string? text, ImmutableArray<Trivia> leadingTrivia, int width) : SyntaxNode
 {
-    public override IEnumerable<SyntaxNode> Children => [];
+    public override IEnumerable<SyntaxNode> Children => LeadingTrivia;
 
     public TokenKind Kind { get; } = kind;
 
@@ -14,7 +14,7 @@ internal sealed class Token(TokenKind kind, string? text, string leadingTrivia, 
         $"Cannot create a token with kind '{kind}' without explicitly " +
         $"specifying its text because the kind does not have a constant string");
     
-    public string LeadingTrivia { get; } = leadingTrivia;
+    public ImmutableArray<Trivia> LeadingTrivia { get; } = leadingTrivia;
 
     public override int GetFullWidth() => FullWidth;
 

--- a/src/compiler/Syntax/Green/Token.cs
+++ b/src/compiler/Syntax/Green/Token.cs
@@ -25,7 +25,7 @@ internal sealed class Token(TokenKind kind, string? text, ImmutableArray<Trivia>
     /// followed by an <see cref="UnexpectedTokenTrivia"/> constructed from the token.
     /// </summary>
     public IEnumerable<Trivia> ToTriviaFollowedByUnexpectedToken() =>
-        LeadingTrivia.Append(new UnexpectedTokenTrivia(this));
+        LeadingTrivia.Append(new UnexpectedTokenTrivia(Kind, Text, width));
 
     public override string ToString() => Text;
 }

--- a/src/compiler/Syntax/Green/Token.cs
+++ b/src/compiler/Syntax/Green/Token.cs
@@ -8,7 +8,7 @@ internal sealed class Token(TokenKind kind, string? text, ImmutableArray<Trivia>
 
     public TokenKind Kind { get; } = kind;
 
-    public int FullWidth { get; } = width + leadingTrivia.Length;
+    public int FullWidth { get; } = width + leadingTrivia.Sum(x => x.GetFullWidth());
 
     public string Text { get; } = text ?? kind.ConstantString() ?? throw new InvalidOperationException(
         $"Cannot create a token with kind '{kind}' without explicitly " +

--- a/src/compiler/Syntax/Green/Token.cs
+++ b/src/compiler/Syntax/Green/Token.cs
@@ -21,6 +21,62 @@ internal sealed class Token(TokenKind kind, string? text, ImmutableArray<Trivia>
     public override Syntax.SyntaxNode ToRed(int position, Syntax.SyntaxNode parent) => new Syntax.Token(this, position, parent);
 
     /// <summary>
+    /// Returns the token with a new set of leading trivia.
+    /// </summary>
+    /// <param name="trivia">The new leading trivia.</param>
+    public Token WithTrivia(ImmutableArray<Trivia> trivia) =>
+        new(Kind, Text, trivia, width);
+    
+    private Token AddTokenAsTrivia(Token token, Func<Token, Trivia> createTrivia)
+    {
+        var trivia = createTrivia(token);
+        ReadOnlySpan<Trivia> appendTrivia = [..token.LeadingTrivia, trivia];
+        var newTrivia = LeadingTrivia.InsertRange(0, appendTrivia);
+
+        var newToken = WithTrivia(newTrivia);
+
+        if (token.Diagnostics.Count > 0)
+        {
+            var existingTriviaWidth = token.LeadingTrivia.Sum(x => x.GetFullWidth());
+
+            foreach (var diagnostic in token.Diagnostics)
+            {
+                newToken.AddDiagnostic(diagnostic.AddOffset(-existingTriviaWidth));
+            }
+        }
+
+        return newToken;
+    }
+
+    /// <summary>
+    /// Returns the token with another token appended as unexpected token trivia.
+    /// The other token will have its own leading trivia appended to the new token's trivia as well.
+    /// </summary>
+    /// <param name="unexpected">The token to append as an unexpected token.</param>
+    public Token AddTokenAsUnexpectedTrivia(Token unexpected) =>
+        AddTokenAsTrivia(unexpected, t => t.ToUnexpectedTokenTrivia());
+
+    /// <summary>
+    /// Returns the token with another token appended as skipped token trivia.
+    /// The other token will have its own leading trivia appended to the new token's trivia as well.
+    /// </summary>
+    /// <param name="unexpected">The token to append as a skipped token.</param>
+    public Token AddTokenAsSkippedTrivia(Token skipped) =>
+        AddTokenAsTrivia(skipped, t => t.ToSkippedTokenTrivia());
+
+    /// <summary>
+    /// Converts the token into an <see cref="UnexpectedTokenTrivia"/>.
+    /// </summary>
+    public UnexpectedTokenTrivia ToUnexpectedTokenTrivia() =>
+        new(Kind, Text, width);
+
+    /// <summary>
+    /// Converts the token into an <see cref="SkippedTokenTrivia"/>.
+    /// </summary>
+    public SkippedTokenTrivia ToSkippedTokenTrivia() =>
+        new(Kind, Text, width);
+
+    /// <summary>
     /// Returns a sequence of the token's trivia
     /// followed by an <see cref="UnexpectedTokenTrivia"/> constructed from the token.
     /// </summary>

--- a/src/compiler/Syntax/Green/Token.cs
+++ b/src/compiler/Syntax/Green/Token.cs
@@ -4,7 +4,7 @@ namespace Noa.Compiler.Syntax.Green;
 
 internal sealed class Token(TokenKind kind, string? text, ImmutableArray<Trivia> leadingTrivia, int width) : SyntaxNode
 {
-    public override IEnumerable<SyntaxNode> Children => LeadingTrivia;
+    public override IEnumerable<SyntaxNode> Children => [];
 
     public TokenKind Kind { get; } = kind;
 

--- a/src/compiler/Syntax/Green/Trivia.cs
+++ b/src/compiler/Syntax/Green/Trivia.cs
@@ -1,0 +1,56 @@
+
+namespace Noa.Compiler.Syntax.Green;
+
+/// <summary>
+/// Trivia associated with a <see cref="Token"/>
+/// which doesn't have any significance syntactically.
+/// </summary>
+internal abstract class Trivia : SyntaxNode;
+
+internal sealed class WhitespaceTrivia(string whitespace) : Trivia
+{
+    public string WhitespaceText { get; } = whitespace;
+
+    public override IEnumerable<SyntaxNode> Children => [];
+
+    public override Syntax.WhitespaceTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+        new(this, fullPosition, parent);
+
+    public override int GetFullWidth() => WhitespaceText.Length;
+}
+
+internal sealed class CommentTrivia(string fullText) : Trivia
+{
+    public string FullText { get; } = fullText;
+
+    public override IEnumerable<SyntaxNode> Children => [];
+
+    public override Syntax.CommentTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+        new(this, fullPosition, parent);
+
+    public override int GetFullWidth() => FullText.Length;
+}
+
+internal sealed class UnexpectedTokenTrivia(Token token) : Trivia
+{
+    public Token Token { get; } = token;
+
+    public override IEnumerable<SyntaxNode> Children => [Token];
+
+    public override Syntax.UnexpectedTokenTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+        new(this, fullPosition, parent);
+
+    public override int GetFullWidth() => Token.FullWidth;
+}
+
+internal sealed class UnexpectedCharacterTrivia(string character) : Trivia
+{
+    public string Character { get; } = character;
+
+    public override IEnumerable<SyntaxNode> Children => [];
+
+    public override Syntax.UnexpectedCharacterTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+        new(this, fullPosition, parent);
+
+    public override int GetFullWidth() => Character.Length;
+}

--- a/src/compiler/Syntax/Green/Trivia.cs
+++ b/src/compiler/Syntax/Green/Trivia.cs
@@ -40,7 +40,7 @@ internal sealed class UnexpectedTokenTrivia(TokenKind kind, string text, int wid
     public override int GetFullWidth() => width;
 }
 
-internal sealed class SkippedTokenTrivia(TokenKind kind, string text, int widthh) : Trivia
+internal sealed class SkippedTokenTrivia(TokenKind kind, string text, int width) : Trivia
 {
     public TokenKind Kind { get; } = kind;
 
@@ -49,7 +49,7 @@ internal sealed class SkippedTokenTrivia(TokenKind kind, string text, int widthh
     public override Syntax.SkippedTokenTrivia ToRed(int fullPosition, Syntax.Token parent) =>
         new(this, fullPosition, parent);
 
-    public override int GetFullWidth() => throw new NotImplementedException();
+    public override int GetFullWidth() => width;
 }
 
 internal sealed class UnexpectedCharacterTrivia(string character) : Trivia

--- a/src/compiler/Syntax/Green/Trivia.cs
+++ b/src/compiler/Syntax/Green/Trivia.cs
@@ -40,6 +40,18 @@ internal sealed class UnexpectedTokenTrivia(TokenKind kind, string text, int wid
     public override int GetFullWidth() => width;
 }
 
+internal sealed class SkippedTokenTrivia(TokenKind kind, string text, int widthh) : Trivia
+{
+    public TokenKind Kind { get; } = kind;
+
+    public string Text { get; } = text;
+
+    public override Syntax.SkippedTokenTrivia ToRed(int fullPosition, Syntax.Token parent) =>
+        new(this, fullPosition, parent);
+
+    public override int GetFullWidth() => throw new NotImplementedException();
+}
+
 internal sealed class UnexpectedCharacterTrivia(string character) : Trivia
 {
     public string Character { get; } = character;

--- a/src/compiler/Syntax/Green/Trivia.cs
+++ b/src/compiler/Syntax/Green/Trivia.cs
@@ -28,14 +28,16 @@ internal sealed class CommentTrivia(string fullText) : Trivia
     public override int GetFullWidth() => FullText.Length;
 }
 
-internal sealed class UnexpectedTokenTrivia(Token token) : Trivia
+internal sealed class UnexpectedTokenTrivia(TokenKind kind, string text, int width) : Trivia
 {
-    public Token Token { get; } = token;
+    public TokenKind Kind { get; } = kind;
+
+    public string Text { get; } = text;
 
     public override Syntax.UnexpectedTokenTrivia ToRed(int fullPosition, Syntax.Token parent) =>
         new(this, fullPosition, parent);
 
-    public override int GetFullWidth() => Token.FullWidth;
+    public override int GetFullWidth() => width;
 }
 
 internal sealed class UnexpectedCharacterTrivia(string character) : Trivia

--- a/src/compiler/Syntax/Green/Trivia.cs
+++ b/src/compiler/Syntax/Green/Trivia.cs
@@ -1,19 +1,18 @@
-
 namespace Noa.Compiler.Syntax.Green;
 
-/// <summary>
-/// Trivia associated with a <see cref="Token"/>
-/// which doesn't have any significance syntactically.
-/// </summary>
-internal abstract class Trivia : SyntaxNode;
+/// <inheritdoc cref="Syntax.Trivia"/>
+internal abstract class Trivia
+{
+    public abstract Syntax.Trivia ToRed(int fullPosition, Syntax.Token parent);
+
+    public abstract int GetFullWidth();
+}
 
 internal sealed class WhitespaceTrivia(string whitespace) : Trivia
 {
     public string WhitespaceText { get; } = whitespace;
 
-    public override IEnumerable<SyntaxNode> Children => [];
-
-    public override Syntax.WhitespaceTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+    public override Syntax.WhitespaceTrivia ToRed(int fullPosition, Syntax.Token parent) =>
         new(this, fullPosition, parent);
 
     public override int GetFullWidth() => WhitespaceText.Length;
@@ -23,9 +22,7 @@ internal sealed class CommentTrivia(string fullText) : Trivia
 {
     public string FullText { get; } = fullText;
 
-    public override IEnumerable<SyntaxNode> Children => [];
-
-    public override Syntax.CommentTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+    public override Syntax.CommentTrivia ToRed(int fullPosition, Syntax.Token parent) =>
         new(this, fullPosition, parent);
 
     public override int GetFullWidth() => FullText.Length;
@@ -35,9 +32,7 @@ internal sealed class UnexpectedTokenTrivia(Token token) : Trivia
 {
     public Token Token { get; } = token;
 
-    public override IEnumerable<SyntaxNode> Children => [Token];
-
-    public override Syntax.UnexpectedTokenTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+    public override Syntax.UnexpectedTokenTrivia ToRed(int fullPosition, Syntax.Token parent) =>
         new(this, fullPosition, parent);
 
     public override int GetFullWidth() => Token.FullWidth;
@@ -47,9 +42,7 @@ internal sealed class UnexpectedCharacterTrivia(string character) : Trivia
 {
     public string Character { get; } = character;
 
-    public override IEnumerable<SyntaxNode> Children => [];
-
-    public override Syntax.UnexpectedCharacterTrivia ToRed(int fullPosition, Syntax.SyntaxNode parent) =>
+    public override Syntax.UnexpectedCharacterTrivia ToRed(int fullPosition, Syntax.Token parent) =>
         new(this, fullPosition, parent);
 
     public override int GetFullWidth() => Character.Length;

--- a/src/compiler/Syntax/ISyntaxNavigable.cs
+++ b/src/compiler/Syntax/ISyntaxNavigable.cs
@@ -1,0 +1,34 @@
+namespace Noa.Compiler.Syntax;
+
+/// <summary>
+/// Syntax which can be navigated through.
+/// </summary>
+public interface ISyntaxNavigable
+{
+    /// <summary>
+    /// Gets the first token within the syntax.
+    /// </summary>
+    /// <param name="includeInvisible">
+    /// Whether to include invisible tokens.
+    /// If <see langword="true"/>, the method will return <see langword="null"/>
+    /// if the syntax does not have any visible tokens.
+    /// </param>
+    ITokenLike? GetFirstToken(bool includeInvisible = false);
+
+    /// <summary>
+    /// Gets the last token within the syntax.
+    /// </summary>
+    /// <param name="includeInvisible">
+    /// Whether to include invisible tokens.
+    /// If <see langword="true"/>, the method will return <see langword="null"/>
+    /// if the syntax does not have any visible tokens.
+    /// </param>
+    ITokenLike? GetLastToken(bool includeInvisible = false);
+
+    /// <summary>
+    /// Gets the token preceding the syntax.
+    /// </summary>
+    /// <returns>The preceding token, or <see langword="null"/> if none could be found.</returns>
+    /// <param name="includeInvisible">Whether to include invisible tokens.</param>
+    ITokenLike? GetPreviousToken(bool includeInvisible = false);
+}

--- a/src/compiler/Syntax/ITokenLike.cs
+++ b/src/compiler/Syntax/ITokenLike.cs
@@ -1,0 +1,25 @@
+using TextMappingUtils;
+
+namespace Noa.Compiler.Syntax;
+
+/// <summary>
+/// Anything token-like, including <see cref="Token"/> and <see cref="UnexpectedTokenTrivia"/>.
+/// </summary>
+public interface ITokenLike
+{
+    /// <summary>
+    /// The kind of the token.
+    /// </summary>
+    TokenKind Kind { get; }
+
+    /// <summary>
+    /// The text of the token.
+    /// </summary>
+    string Text { get; }
+
+    /// <summary>
+    /// The span of the token, <b>not</b> including leading trivia.
+    /// That is, the span of the text of the token.
+    /// </summary>
+    TextSpan Span { get; }
+}

--- a/src/compiler/Syntax/ITokenLike.cs
+++ b/src/compiler/Syntax/ITokenLike.cs
@@ -5,7 +5,7 @@ namespace Noa.Compiler.Syntax;
 /// <summary>
 /// Anything token-like, including <see cref="Token"/> and <see cref="UnexpectedTokenTrivia"/>.
 /// </summary>
-public interface ITokenLike
+public interface ITokenLike : ISyntaxNavigable
 {
     /// <summary>
     /// The kind of the token.

--- a/src/compiler/Syntax/SyntaxNavigation.cs
+++ b/src/compiler/Syntax/SyntaxNavigation.cs
@@ -31,7 +31,7 @@ public abstract partial class SyntaxNode
         GetFirstToken(includeInvisible, node => node.Children.Reverse());
 
     public virtual ITokenLike? GetPreviousToken(bool includeInvisible = false) =>
-        SyntaxUtilities.GetPreviousTokenForNodeOrToken(this, includeInvisible);
+        SyntaxNavigation.GetPreviousTokenForNodeOrToken(this, includeInvisible);
 }
 
 public sealed partial class Token
@@ -66,7 +66,7 @@ public sealed partial class Token
         if (GetLastToken(includeInvisible) is { } unexpectedToken) return unexpectedToken;
 
         // Delegate to the common utility method.
-        return SyntaxUtilities.GetPreviousTokenForNodeOrToken(this, includeInvisible);
+        return SyntaxNavigation.GetPreviousTokenForNodeOrToken(this, includeInvisible);
     }
 }
 
@@ -81,7 +81,7 @@ public sealed partial class UnexpectedTokenTrivia
 
     public ITokenLike? GetPreviousToken(bool includeInvisible = false)
     {
-        foreach (var sibling in SyntaxUtilities.IteratePreviousUnexpectedTokens(this))
+        foreach (var sibling in SyntaxNavigation.IteratePreviousUnexpectedTokens(this))
         {
             if (!sibling.Kind.IsInvisible() || includeInvisible) return sibling;
         }
@@ -90,7 +90,7 @@ public sealed partial class UnexpectedTokenTrivia
     }
 }
 
-public static class SyntaxUtilities
+public static class SyntaxNavigation
 {
     /// <summary>
     /// Gets the first ancestor of a specified type of a node and optionally matching a filter.

--- a/src/compiler/Syntax/SyntaxNode.cs
+++ b/src/compiler/Syntax/SyntaxNode.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Noa.Compiler.Diagnostics;
 using TextMappingUtils;
 
 namespace Noa.Compiler.Syntax;
@@ -62,6 +63,13 @@ public abstract class SyntaxNode
         if (leadingTrivia is not null) width -= leadingTrivia.Length;
         return width;
     }
+
+    /// <summary>
+    /// Gets all diagnostics associated with this node.
+    /// </summary>
+    /// <param name="source">The source of the node.</param>
+    public IEnumerable<IDiagnostic> GetDiagnostics(Source source) =>
+        Green.Diagnostics.Select(diag => diag.Format(source, FullPosition));
 
     /// <summary>
     /// The nodes which are direct children of the node.

--- a/src/compiler/Syntax/SyntaxNode.cs
+++ b/src/compiler/Syntax/SyntaxNode.cs
@@ -7,7 +7,7 @@ namespace Noa.Compiler.Syntax;
 /// <summary>
 /// A concrete syntax node. Holds exact information about the syntax of a program.
 /// </summary>
-// Note: the implementation of ISyntaxNavigable is in SyntaxUtilities.cs.
+// Note: the implementation of ISyntaxNavigable is in SyntaxNavigation.cs.
 public abstract partial class SyntaxNode : ISyntaxNavigable
 {
     /// <summary>

--- a/src/compiler/Syntax/SyntaxNode.cs
+++ b/src/compiler/Syntax/SyntaxNode.cs
@@ -11,6 +11,7 @@ public abstract class SyntaxNode
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private TextSpan? span = null;
+    private int? leadingTriviaWidth;
 
     /// <summary>
     /// The corresponding node in the green tree.
@@ -33,16 +34,7 @@ public abstract class SyntaxNode
     /// The position of the node in the tree.
     /// This does <b>not</b> include leading trivia.
     /// </summary>
-    public int Position
-    {
-        get
-        {
-            var position = FullPosition;
-            var leadingTrivia = Green.FirstToken?.LeadingTrivia;
-            if (leadingTrivia is not null) position += leadingTrivia.Length;
-            return position;
-        }
-    }
+    public int Position => FullPosition + GetTriviaWidth();
 
     /// <summary>
     /// The span of the syntax node in the corresponding source text,
@@ -56,13 +48,11 @@ public abstract class SyntaxNode
     /// </summary>
     public TextSpan FullSpan => TextSpan.FromLength(FullPosition, Green.GetFullWidth());
 
-    private int CalculateNonTriviaWidth()
-    {
-        var width = Green.GetFullWidth();
-        var leadingTrivia = Green.FirstToken?.LeadingTrivia;
-        if (leadingTrivia is not null) width -= leadingTrivia.Length;
-        return width;
-    }
+    private int CalculateNonTriviaWidth() =>
+        Green.GetFullWidth() - GetTriviaWidth();
+
+    private int GetTriviaWidth() => leadingTriviaWidth ??=
+        Green.FirstToken?.LeadingTrivia.Sum(x => x.GetFullWidth()) ?? 0;
 
     /// <summary>
     /// Gets all diagnostics associated with this node.

--- a/src/compiler/Syntax/SyntaxNode.cs
+++ b/src/compiler/Syntax/SyntaxNode.cs
@@ -9,10 +9,6 @@ namespace Noa.Compiler.Syntax;
 /// </summary>
 public abstract class SyntaxNode
 {
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private TextSpan? span = null;
-    private int? leadingTriviaWidth;
-
     /// <summary>
     /// The corresponding node in the green tree.
     /// </summary>
@@ -40,7 +36,7 @@ public abstract class SyntaxNode
     /// The span of the syntax node in the corresponding source text,
     /// <i>excluding</i> its leading trivia.
     /// </summary>
-    public TextSpan Span => span ??= TextSpan.FromLength(Position, CalculateNonTriviaWidth());
+    public TextSpan Span => TextSpan.FromLength(Position, CalculateNonTriviaWidth());
 
     /// <summary>
     /// The full span of the syntax node in the corresponding source text,
@@ -51,8 +47,7 @@ public abstract class SyntaxNode
     private int CalculateNonTriviaWidth() =>
         Green.GetFullWidth() - GetTriviaWidth();
 
-    private int GetTriviaWidth() => leadingTriviaWidth ??=
-        Green.FirstToken?.LeadingTrivia.Sum(x => x.GetFullWidth()) ?? 0;
+    private int GetTriviaWidth() => Green.FirstToken?.LeadingTrivia.Sum(x => x.GetFullWidth()) ?? 0;
 
     /// <summary>
     /// Gets all diagnostics associated with this node.

--- a/src/compiler/Syntax/SyntaxNode.cs
+++ b/src/compiler/Syntax/SyntaxNode.cs
@@ -7,7 +7,8 @@ namespace Noa.Compiler.Syntax;
 /// <summary>
 /// A concrete syntax node. Holds exact information about the syntax of a program.
 /// </summary>
-public abstract class SyntaxNode
+// Note: the implementation of ISyntaxNavigable is in SyntaxUtilities.cs.
+public abstract partial class SyntaxNode : ISyntaxNavigable
 {
     /// <summary>
     /// The corresponding node in the green tree.

--- a/src/compiler/Syntax/SyntaxNode.cs
+++ b/src/compiler/Syntax/SyntaxNode.cs
@@ -55,7 +55,7 @@ public abstract partial class SyntaxNode : ISyntaxNavigable
     /// </summary>
     /// <param name="source">The source of the node.</param>
     public IEnumerable<IDiagnostic> GetDiagnostics(Source source) =>
-        Green.Diagnostics.Select(diag => diag.Format(source, FullPosition));
+        Green.Diagnostics.Select(diag => diag.Format(source, Position));
 
     /// <summary>
     /// The nodes which are direct children of the node.

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -3,7 +3,7 @@ namespace Noa.Compiler.Syntax;
 /// <summary>
 /// A syntax token, a single unit of syntax.
 /// </summary>
-public sealed class Token : SyntaxNode
+public sealed class Token : SyntaxNode, ITokenLike
 {
     private readonly Green.Token green;
 

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -6,7 +6,6 @@ namespace Noa.Compiler.Syntax;
 public sealed class Token : SyntaxNode
 {
     private readonly Green.Token green;
-    private ImmutableArray<Trivia>? leadingTrivia = null;
 
     internal override Green.SyntaxNode Green => green;
 
@@ -25,7 +24,7 @@ public sealed class Token : SyntaxNode
     /// <summary>
     /// The leading trivia of the token.
     /// </summary>
-    public ImmutableArray<Trivia> LeadingTrivia => leadingTrivia ??= ConstructTrivia();
+    public ImmutableArray<Trivia> LeadingTrivia => ConstructTrivia();
 
     private ImmutableArray<Trivia> ConstructTrivia()
     {

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -1,3 +1,5 @@
+using Noa.Compiler.Parsing;
+
 namespace Noa.Compiler.Syntax;
 
 /// <summary>
@@ -45,7 +47,7 @@ public sealed class Token : SyntaxNode, ITokenLike
     /// This is only the case for tokens with the kind
     /// <see cref="TokenKind.Error"/> or <see cref="TokenKind.EndOfFile"/>.
     /// </summary>
-    public bool IsInvisible => Kind is TokenKind.Error or TokenKind.EndOfFile;
+    public bool IsInvisible => Kind.IsInvisible();
 
     internal Token(Green.Token green, int position, SyntaxNode parent) : base(position, parent) =>
         this.green = green;

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -1,4 +1,3 @@
-
 namespace Noa.Compiler.Syntax;
 
 /// <summary>
@@ -11,7 +10,7 @@ public sealed class Token : SyntaxNode
 
     internal override Green.SyntaxNode Green => green;
 
-    public override IEnumerable<SyntaxNode> Children => LeadingTrivia;
+    public override IEnumerable<SyntaxNode> Children => [];
 
     /// <summary>
     /// The kind of the token.
@@ -28,17 +27,8 @@ public sealed class Token : SyntaxNode
     /// </summary>
     public ImmutableArray<Trivia> LeadingTrivia => leadingTrivia ??=
         green.LeadingTrivia
-            .Select(x => (Trivia)x.ToRed(FullPosition, this))
+            .Select(x => x.ToRed(FullPosition, this))
             .ToImmutableArray();
-
-    /// <summary>
-    /// The full leading trivia of the token.
-    /// This includes any leading trivia <i>within</i> the trivia of the current token,
-    /// namely within <see cref="UnexpectedTokenTrivia"/>.
-    /// </summary>
-    public IEnumerable<Trivia> FullLeadingTrivia => LeadingTrivia
-        .OfType<UnexpectedTokenTrivia>()
-        .SelectMany(x => x.Token.FullLeadingTrivia.Prepend(x));
 
     /// <summary>
     /// Whether the token is invisible, i.e. does not consist of any text.

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -25,10 +25,21 @@ public sealed class Token : SyntaxNode
     /// <summary>
     /// The leading trivia of the token.
     /// </summary>
-    public ImmutableArray<Trivia> LeadingTrivia => leadingTrivia ??=
-        green.LeadingTrivia
-            .Select(x => x.ToRed(FullPosition, this))
-            .ToImmutableArray();
+    public ImmutableArray<Trivia> LeadingTrivia => leadingTrivia ??= ConstructTrivia();
+
+    private ImmutableArray<Trivia> ConstructTrivia()
+    {
+        var builder = ImmutableArray.CreateBuilder<Trivia>(green.LeadingTrivia.Length);
+
+        var offset = 0;
+        foreach (var trivia in green.LeadingTrivia)
+        {
+            builder.Add(trivia.ToRed(FullPosition + offset, this));
+            offset += trivia.GetFullWidth();
+        }
+
+        return builder.MoveToImmutable();
+    }
 
     /// <summary>
     /// Whether the token is invisible, i.e. does not consist of any text.

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -5,7 +5,7 @@ namespace Noa.Compiler.Syntax;
 /// <summary>
 /// A syntax token, a single unit of syntax.
 /// </summary>
-// Note: the implementation of ISyntaxNavigable is in SyntaxUtilities.cs.
+// Note: the implementation of ISyntaxNavigable is in SyntaxNavigation.cs.
 public sealed partial class Token : SyntaxNode, ITokenLike
 {
     private readonly Green.Token green;

--- a/src/compiler/Syntax/Token.cs
+++ b/src/compiler/Syntax/Token.cs
@@ -5,7 +5,8 @@ namespace Noa.Compiler.Syntax;
 /// <summary>
 /// A syntax token, a single unit of syntax.
 /// </summary>
-public sealed class Token : SyntaxNode, ITokenLike
+// Note: the implementation of ISyntaxNavigable is in SyntaxUtilities.cs.
+public sealed partial class Token : SyntaxNode, ITokenLike
 {
     private readonly Green.Token green;
 

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -93,6 +93,23 @@ public sealed partial class UnexpectedTokenTrivia : Trivia, ITokenLike
 }
 
 /// <summary>
+/// Trivia about a single skipped token.
+/// </summary>
+// Note: the implementation of ISyntaxNavigable is in SyntaxNavigation.cs.
+public sealed partial class SkippedTokenTrivia : Trivia, ITokenLike
+{
+    private readonly Green.SkippedTokenTrivia green;
+
+    public TokenKind Kind => green.Kind;
+
+    public string Text => green.Text;
+
+    internal SkippedTokenTrivia(Green.SkippedTokenTrivia green, int fullPosition, Token parent)
+        : base(green, fullPosition, parent) =>
+        this.green = green;
+}
+
+/// <summary>
 /// Trivia about a single unexpected character.
 /// </summary>
 public sealed class UnexpectedCharacterTrivia : Trivia

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -83,9 +83,9 @@ public sealed partial class UnexpectedTokenTrivia : Trivia, ITokenLike
 {
     private readonly Green.UnexpectedTokenTrivia green;
 
-    public TokenKind Kind => green.Token.Kind;
+    public TokenKind Kind => green.Kind;
 
-    public string Text => green.Token.Text;
+    public string Text => green.Text;
 
     internal UnexpectedTokenTrivia(Green.UnexpectedTokenTrivia green, int fullPosition, Token parent)
         : base(green, fullPosition, parent) =>

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -78,7 +78,8 @@ public sealed class CommentTrivia : Trivia
 /// <summary>
 /// Trivia about a single unexpected token.
 /// </summary>
-public sealed class UnexpectedTokenTrivia : Trivia, ITokenLike
+// Note: the implementation of ISyntaxNavigable is in SyntaxUtilities.cs.
+public sealed partial class UnexpectedTokenTrivia : Trivia, ITokenLike
 {
     private readonly Green.UnexpectedTokenTrivia green;
 

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -28,6 +28,12 @@ public abstract class Trivia
         this.fullPosition = fullPosition;
         ParentToken = parent;
     }
+
+    public override bool Equals(object? obj) =>
+        obj is Trivia trivia &&
+        trivia.green == green;
+
+    public override int GetHashCode() => green.GetHashCode();
 }
 
 /// <summary>

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -8,7 +8,7 @@ namespace Noa.Compiler.Syntax;
 /// </summary>
 public abstract class Trivia
 {
-    private readonly Green.Trivia green;
+    internal readonly Green.Trivia green;
     private readonly int fullPosition;
 
     /// <summary>
@@ -42,7 +42,7 @@ public abstract class Trivia
 /// <param name="whitespace">The whitespace of the token.</param>
 public sealed class WhitespaceTrivia : Trivia
 {
-    private readonly Green.WhitespaceTrivia green;
+    private new readonly Green.WhitespaceTrivia green;
 
     /// <summary>
     /// The whitespace text.
@@ -63,7 +63,7 @@ public sealed class WhitespaceTrivia : Trivia
 /// </remarks>
 public sealed class CommentTrivia : Trivia
 {
-    private readonly Green.CommentTrivia green;
+    private new readonly Green.CommentTrivia green;
 
     /// <summary>
     /// The full text of the comment, including the leading <c>//</c>.
@@ -87,7 +87,7 @@ public sealed class CommentTrivia : Trivia
 // Note: the implementation of ISyntaxNavigable is in SyntaxNavigation.cs.
 public sealed partial class UnexpectedTokenTrivia : Trivia, ITokenLike
 {
-    private readonly Green.UnexpectedTokenTrivia green;
+    private new readonly Green.UnexpectedTokenTrivia green;
 
     public TokenKind Kind => green.Kind;
 
@@ -104,7 +104,7 @@ public sealed partial class UnexpectedTokenTrivia : Trivia, ITokenLike
 // Note: the implementation of ISyntaxNavigable is in SyntaxNavigation.cs.
 public sealed partial class SkippedTokenTrivia : Trivia, ITokenLike
 {
-    private readonly Green.SkippedTokenTrivia green;
+    private new readonly Green.SkippedTokenTrivia green;
 
     public TokenKind Kind => green.Kind;
 
@@ -120,7 +120,7 @@ public sealed partial class SkippedTokenTrivia : Trivia, ITokenLike
 /// </summary>
 public sealed class UnexpectedCharacterTrivia : Trivia
 {
-    private readonly Green.UnexpectedCharacterTrivia green;
+    private new readonly Green.UnexpectedCharacterTrivia green;
 
     /// <summary>
     /// The unexpected character.

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -17,9 +17,10 @@ public abstract class Trivia
     public Token ParentToken { get; }
 
     /// <summary>
-    /// The full span of the trivia.
+    /// The span of the trivia.
+    /// Compared to syntax nodes, this is already the "full" span.
     /// </summary>
-    public TextSpan FullSpan => TextSpan.FromLength(fullPosition, green.GetFullWidth());
+    public TextSpan Span => TextSpan.FromLength(fullPosition, green.GetFullWidth());
 
     internal Trivia(Green.Trivia green, int fullPosition, Token parent)
     {

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -78,9 +78,13 @@ public sealed class CommentTrivia : Trivia
 /// <summary>
 /// Trivia about a single unexpected token.
 /// </summary>
-public sealed class UnexpectedTokenTrivia : Trivia
+public sealed class UnexpectedTokenTrivia : Trivia, ITokenLike
 {
     private readonly Green.UnexpectedTokenTrivia green;
+
+    public TokenKind Kind => green.Token.Kind;
+
+    public string Text => green.Token.Text;
 
     internal UnexpectedTokenTrivia(Green.UnexpectedTokenTrivia green, int fullPosition, Token parent)
         : base(green, fullPosition, parent) =>

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -1,12 +1,32 @@
+using TextMappingUtils;
+
 namespace Noa.Compiler.Syntax;
 
 /// <summary>
 /// Trivia associated with a <see cref="Token"/>
 /// which doesn't have any significance syntactically.
 /// </summary>
-public abstract class Trivia : SyntaxNode
+public abstract class Trivia
 {
-    internal Trivia(int fullPosition, SyntaxNode parent) : base(fullPosition, parent) { }
+    private readonly Green.Trivia green;
+    private readonly int fullPosition;
+
+    /// <summary>
+    /// The parent token which the trivia is trivia of.
+    /// </summary>
+    public Token ParentToken { get; }
+
+    /// <summary>
+    /// The full span of the trivia.
+    /// </summary>
+    public TextSpan FullSpan => TextSpan.FromLength(fullPosition, green.GetFullWidth());
+
+    internal Trivia(Green.Trivia green, int fullPosition, Token parent)
+    {
+        this.green = green;
+        this.fullPosition = fullPosition;
+        ParentToken = parent;
+    }
 }
 
 /// <summary>
@@ -17,17 +37,13 @@ public sealed class WhitespaceTrivia : Trivia
 {
     private readonly Green.WhitespaceTrivia green;
 
-    internal override Green.SyntaxNode Green => green;
-
-    public override IEnumerable<SyntaxNode> Children => [];
-
     /// <summary>
     /// The whitespace text.
     /// </summary>
     public string WhitespaceText => green.WhitespaceText;
 
-    internal WhitespaceTrivia(Green.WhitespaceTrivia green, int fullPosition, SyntaxNode parent)
-        : base(fullPosition, parent) =>
+    internal WhitespaceTrivia(Green.WhitespaceTrivia green, int fullPosition, Token parent)
+        : base(green, fullPosition, parent) =>
         this.green = green;
 }
 
@@ -42,10 +58,6 @@ public sealed class CommentTrivia : Trivia
 {
     private readonly Green.CommentTrivia green;
 
-    internal override Green.SyntaxNode Green => green;
-
-    public override IEnumerable<SyntaxNode> Children => [];
-
     /// <summary>
     /// The full text of the comment, including the leading <c>//</c>.
     /// </summary>
@@ -57,8 +69,8 @@ public sealed class CommentTrivia : Trivia
     /// </summary>
     public string CommentText => FullText[2..];
 
-    internal CommentTrivia(Green.CommentTrivia green, int fullPosition, SyntaxNode parent)
-        : base(fullPosition, parent) =>
+    internal CommentTrivia(Green.CommentTrivia green, int fullPosition, Token parent)
+        : base(green, fullPosition, parent) =>
         this.green = green;
 }
 
@@ -69,18 +81,8 @@ public sealed class UnexpectedTokenTrivia : Trivia
 {
     private readonly Green.UnexpectedTokenTrivia green;
 
-    internal override Green.SyntaxNode Green => green;
-
-    public override IEnumerable<SyntaxNode> Children => [Token];
-
-    /// <summary>
-    /// The unexpected token.
-    /// This token might have trivia of itself, potentially forming a sub-tree of trivia.
-    /// </summary>
-    public Token Token => new(green.Token, FullPosition, this);
-
-    internal UnexpectedTokenTrivia(Green.UnexpectedTokenTrivia green, int fullPosition, SyntaxNode parent)
-        : base(fullPosition, parent) =>
+    internal UnexpectedTokenTrivia(Green.UnexpectedTokenTrivia green, int fullPosition, Token parent)
+        : base(green, fullPosition, parent) =>
         this.green = green;
 }
 
@@ -91,17 +93,13 @@ public sealed class UnexpectedCharacterTrivia : Trivia
 {
     private readonly Green.UnexpectedCharacterTrivia green;
 
-    internal override Green.SyntaxNode Green => green;
-
-    public override IEnumerable<SyntaxNode> Children => [];
-
     /// <summary>
     /// The unexpected character.
     /// Yes, this is a string and not a char, because emojis.
     /// </summary>
     public string Character => green.Character;
 
-    internal UnexpectedCharacterTrivia(Green.UnexpectedCharacterTrivia green, int fullPosition, SyntaxNode parent)
-        : base(fullPosition, parent) =>
+    internal UnexpectedCharacterTrivia(Green.UnexpectedCharacterTrivia green, int fullPosition, Token parent)
+        : base(green, fullPosition, parent) =>
         this.green = green;
 }

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -78,7 +78,7 @@ public sealed class CommentTrivia : Trivia
 /// <summary>
 /// Trivia about a single unexpected token.
 /// </summary>
-// Note: the implementation of ISyntaxNavigable is in SyntaxUtilities.cs.
+// Note: the implementation of ISyntaxNavigable is in SyntaxNavigation.cs.
 public sealed partial class UnexpectedTokenTrivia : Trivia, ITokenLike
 {
     private readonly Green.UnexpectedTokenTrivia green;

--- a/src/compiler/Syntax/Trivia.cs
+++ b/src/compiler/Syntax/Trivia.cs
@@ -1,0 +1,107 @@
+namespace Noa.Compiler.Syntax;
+
+/// <summary>
+/// Trivia associated with a <see cref="Token"/>
+/// which doesn't have any significance syntactically.
+/// </summary>
+public abstract class Trivia : SyntaxNode
+{
+    internal Trivia(int fullPosition, SyntaxNode parent) : base(fullPosition, parent) { }
+}
+
+/// <summary>
+/// Trivia about whitespace.
+/// </summary>
+/// <param name="whitespace">The whitespace of the token.</param>
+public sealed class WhitespaceTrivia : Trivia
+{
+    private readonly Green.WhitespaceTrivia green;
+
+    internal override Green.SyntaxNode Green => green;
+
+    public override IEnumerable<SyntaxNode> Children => [];
+
+    /// <summary>
+    /// The whitespace text.
+    /// </summary>
+    public string WhitespaceText => green.WhitespaceText;
+
+    internal WhitespaceTrivia(Green.WhitespaceTrivia green, int fullPosition, SyntaxNode parent)
+        : base(fullPosition, parent) =>
+        this.green = green;
+}
+
+/// <summary>
+/// Trivia about a single comment.
+/// </summary>
+/// <remarks>
+/// Comments on consecutive lines do not count as the same comment,
+/// they will be multiple comment trivias with whitespace trivias separating them.
+/// </remarks>
+public sealed class CommentTrivia : Trivia
+{
+    private readonly Green.CommentTrivia green;
+
+    internal override Green.SyntaxNode Green => green;
+
+    public override IEnumerable<SyntaxNode> Children => [];
+
+    /// <summary>
+    /// The full text of the comment, including the leading <c>//</c>.
+    /// </summary>
+    public string FullText => green.FullText;
+
+    /// <summary>
+    /// The comment text, not including the leading <c>//</c>.
+    /// This does include any whitespace immediately after the <c>//</c>, however.
+    /// </summary>
+    public string CommentText => FullText[2..];
+
+    internal CommentTrivia(Green.CommentTrivia green, int fullPosition, SyntaxNode parent)
+        : base(fullPosition, parent) =>
+        this.green = green;
+}
+
+/// <summary>
+/// Trivia about a single unexpected token.
+/// </summary>
+public sealed class UnexpectedTokenTrivia : Trivia
+{
+    private readonly Green.UnexpectedTokenTrivia green;
+
+    internal override Green.SyntaxNode Green => green;
+
+    public override IEnumerable<SyntaxNode> Children => [Token];
+
+    /// <summary>
+    /// The unexpected token.
+    /// This token might have trivia of itself, potentially forming a sub-tree of trivia.
+    /// </summary>
+    public Token Token => new(green.Token, FullPosition, this);
+
+    internal UnexpectedTokenTrivia(Green.UnexpectedTokenTrivia green, int fullPosition, SyntaxNode parent)
+        : base(fullPosition, parent) =>
+        this.green = green;
+}
+
+/// <summary>
+/// Trivia about a single unexpected character.
+/// </summary>
+public sealed class UnexpectedCharacterTrivia : Trivia
+{
+    private readonly Green.UnexpectedCharacterTrivia green;
+
+    internal override Green.SyntaxNode Green => green;
+
+    public override IEnumerable<SyntaxNode> Children => [];
+
+    /// <summary>
+    /// The unexpected character.
+    /// Yes, this is a string and not a char, because emojis.
+    /// </summary>
+    public string Character => green.Character;
+
+    internal UnexpectedCharacterTrivia(Green.UnexpectedCharacterTrivia green, int fullPosition, SyntaxNode parent)
+        : base(fullPosition, parent) =>
+        this.green = green;
+}


### PR DESCRIPTION
Implement parse diagnostics in a semi-immutable way on tokens. Also update a lot of CST-related stuff and restructure trivia. Fixes #76.