### PR TITLE
Fix syntax diagnostic spans

### DIFF
--- a/src/compiler/Parsing/ParserCore.cs
+++ b/src/compiler/Parsing/ParserCore.cs
@@ -26,21 +26,21 @@ internal sealed partial class Parser
         node.AddDiagnostic(new PartialDiagnostic(
             template,
             Offset: offset,
-            Width: node.GetFullWidth()));
+            Width: node.GetSnugWidth()));
 
     private void ReportDiagnostic(DiagnosticTemplate<Token> template, Token token, int offset = 0) =>
         token.AddDiagnostic(new PartialDiagnostic<Token>(
             template,
             token,
             Offset: offset,
-            Width: token.FullWidth));
+            Width: token.Width));
 
     private void ReportDiagnostic<T>(DiagnosticTemplate<T> template, T arg, SyntaxNode node, int offset = 0) =>
         node.AddDiagnostic(new PartialDiagnostic<T>(
             template,
             arg,
             Offset: offset,
-            Width: node.GetFullWidth()));
+            Width: node.GetSnugWidth()));
     
     private Token Advance() => state.Advance();
 

--- a/src/compiler/Syntax/Green/SyntaxNode.cs
+++ b/src/compiler/Syntax/Green/SyntaxNode.cs
@@ -79,6 +79,32 @@ internal abstract class SyntaxNode
     }
 
     /// <summary>
+    /// Gets the width of the node, excluding trivia.
+    /// </summary>
+    public int GetSnugWidth()
+    {
+        var width = 0;
+
+        if (this is Token token) return token.Width;
+
+        var first = true;
+        foreach (var child in Children)
+        {
+            if (first)
+            {
+                width += child.GetSnugWidth();
+                first = false;
+            }
+            else
+            {
+                width += child.GetFullWidth();
+            }
+        }
+
+        return width;
+    }
+
+    /// <summary>
     /// Gets the width of the node, including trivia.
     /// </summary>
     public abstract int GetFullWidth();


### PR DESCRIPTION
Fix syntax diagnostics having incorrect spans, possibly crashing the CLI and language server. Fixes #83, fixes #79.