### PR TITLE
Simplify diagnostics

### DIFF
--- a/src/compiler/Diagnostics/Diagnostic.cs
+++ b/src/compiler/Diagnostics/Diagnostic.cs
@@ -6,14 +6,6 @@ namespace Noa.Compiler.Diagnostics;
 public static class Diagnostic
 {
     /// <summary>
-    /// Creates a simple diagnostic from a diagnostic template and a location.
-    /// </summary>
-    /// <param name="template">The template to create the diagnostic from.</param>
-    /// <param name="location">The location of the diagnostic.</param>
-    public static IDiagnostic Create(DiagnosticTemplate template, Location location) =>
-        new SimpleDiagnostic(template, location);
-
-    /// <summary>
     /// Creates a diagnostic with from a template with an argument and a location.
     /// </summary>
     /// <param name="template">The template to create the diagnostic from.</param>
@@ -48,23 +40,6 @@ public static class Diagnostic
          };
 
          return $"{id}: \"{message}\" ({severityString}) at {location}";
-    }
-    
-    private sealed class SimpleDiagnostic(DiagnosticTemplate template, Location location) : IDiagnostic
-    {
-        public DiagnosticId Id { get; } = template.Id;
-    
-        public Severity Severity { get; } = template.Severity;
-    
-        public Location Location { get; } = location;
-
-        public void WriteToPage(IDiagnosticPage page) => template.WriteMessage(page);
-
-        public override string ToString()
-        {
-            var message = WriteMessage(this, StringDiagnosticWriter.Writer);
-            return DisplayDiagnostic(Id, message, Severity, Location);
-        }
     }
     
     private sealed class ArgumentDiagnostic<TArg>(

--- a/src/compiler/Diagnostics/Diagnostic.cs
+++ b/src/compiler/Diagnostics/Diagnostic.cs
@@ -47,9 +47,9 @@ public static class Diagnostic
         TArg argument,
         Location location) : IDiagnostic
     {
-        public DiagnosticId Id { get; } = template.Id;
+        public DiagnosticId Id => template.Id;
 
-        public Severity Severity { get; } = template.Severity;
+        public Severity Severity => template.Severity;
 
         public Location Location { get; } = location;
 

--- a/src/compiler/Diagnostics/DiagnosticId.cs
+++ b/src/compiler/Diagnostics/DiagnosticId.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace Noa.Compiler.Diagnostics;
@@ -40,9 +41,12 @@ public sealed partial record DiagnosticId : IParsable<DiagnosticId>
     [GeneratedRegex("^([A-Z]+)-([A-Z]+)-([0-9]+)$")]
     private static partial Regex IdRegex();
 
-    public static bool TryParse(string? s, IFormatProvider? provider, out DiagnosticId result)
+    public static bool TryParse(
+        [NotNullWhen(true)] string? s,
+        IFormatProvider? provider,
+        [MaybeNullWhen(false)] out DiagnosticId result)
     {
-        result = null!;
+        result = null;
 
         if (s is null) return false;
 

--- a/src/compiler/Diagnostics/DiagnosticId.cs
+++ b/src/compiler/Diagnostics/DiagnosticId.cs
@@ -1,11 +1,17 @@
-using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Noa.Compiler.Diagnostics;
 
 /// <summary>
 /// The ID of a diagnostic.
 /// </summary>
-public sealed record DiagnosticId : ISpanParsable<DiagnosticId>
+/// <remarks>
+/// A diagnostic ID consists of three parts -
+/// a major name, a category, and a numeric ID.
+/// When parsing an ID, the format should be provided as <c>MAJOR-CATEGORY-NUMERIC</c>,
+/// for instance <c>NOA-OWO-621</c>.
+/// </remarks>
+public sealed partial record DiagnosticId : IParsable<DiagnosticId>
 {
     /// <summary>
     /// The major name of the diagnostic.
@@ -31,55 +37,28 @@ public sealed record DiagnosticId : ISpanParsable<DiagnosticId>
 
     public override string ToString() => $"{Major}-{Category}-{Numeric:D3}";
 
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DiagnosticId result)
+    [GeneratedRegex("^([A-Z]+)-([A-Z]+)-([0-9]+)$")]
+    private static partial Regex IdRegex();
+
+    public static bool TryParse(string? s, IFormatProvider? provider, out DiagnosticId result)
     {
         result = null!;
 
-        var majorStart = 0;
-        var majorLength = 0;
-        for (; majorStart + majorLength < s.Length; majorLength++)
-        {
-            var c = s[majorLength];
-            if (c == '-') break;
-            if (!char.IsAsciiLetter(c)) return false;
-        }
+        if (s is null) return false;
 
-        if (majorLength == 0) return false;
-        var major = s.Slice(majorStart, majorLength).ToString();
+        var match = IdRegex().Match(s);
+        
+        if (!match.Success) return false;
 
-        var categoryStart = majorStart + majorLength + 1;
-        var categoryLength = 0;
-        for (; categoryStart + categoryLength < s.Length; categoryLength++)
-        {
-            var c = s[categoryStart + categoryLength];
-            if (c == '-') break;
-            if (!char.IsAsciiLetter(c)) return false;
-        }
+        var major = match.Groups[1].Value;
+        var category = match.Groups[2].Value;
 
-        if (categoryLength == 0) return false;
-        var category = s.Slice(categoryStart, categoryLength).ToString();
-
-        var numericStart = categoryStart + categoryLength + 1;
-        if (numericStart >= s.Length) return false;
-        if (!int.TryParse(s[numericStart..], NumberStyles.None, CultureInfo.InvariantCulture, out var numeric)) return false;
+        var numericText = match.Groups[3].ValueSpan;
+        if (!int.TryParse(numericText, out var numeric)) return false;
 
         result = new(major, category, numeric);
         return true;
     }
-
-    public static bool TryParse(string? s, IFormatProvider? provider, out DiagnosticId result)
-    {
-        var span = s is not null
-            ? s.AsSpan()
-            : [];
-
-        return TryParse(span, provider, out result);
-    }
-
-    public static DiagnosticId Parse(ReadOnlySpan<char> s, IFormatProvider? provider) =>
-        TryParse(s, provider, out var id)
-            ? id
-            : throw new FormatException($"Cannot parse '{s.ToString()}' into a diagnostic ID.");
     
     public static DiagnosticId Parse(string s, IFormatProvider? provider) =>
         TryParse(s, provider, out var id)

--- a/src/compiler/Diagnostics/DiagnosticTemplate.cs
+++ b/src/compiler/Diagnostics/DiagnosticTemplate.cs
@@ -17,35 +17,21 @@ public interface IDiagnosticTemplate
 }
 
 /// <summary>
-/// A simple template for a diagnostic.
+/// Provides static factory methods for creating diagnostic templates.
 /// </summary>
-/// <param name="WriteMessage">
-/// A function the diagnostic message onto an <see cref="IDiagnosticPage"/>.
-/// </param>
-/// <param name="Severity">The severity of the diagnostic.</param>
-public sealed record DiagnosticTemplate(
-    DiagnosticId Id,
-    Action<IDiagnosticPage> WriteMessage,
-    Severity Severity)
-    : IDiagnosticTemplate
+public static class DiagnosticTemplate
 {
-    /// <summary>
-    /// Formats the template into a diagnostic.
-    /// </summary>
-    /// <param name="location">The location of the diagnostic.</param>
-    public IDiagnostic Format(Location location) =>
-        Diagnostic.Create(this, location);
-
-    public override string ToString() => Id.ToString();
-    
     /// <summary>
     /// Creates a simple diagnostic template.
     /// </summary>
     /// <param name="id">The ID of the diagnostic.</param>
     /// <param name="message">The message of the diagnostic.</param>
     /// <param name="severity">The severity of the diagnostic.</param>
-    public static DiagnosticTemplate Create(DiagnosticId id, string message, Severity severity) =>
-        new(id, page => page.Raw(message), severity);
+    public static DiagnosticTemplate<Unit> Create(
+        DiagnosticId id,
+        string message,
+        Severity severity) =>
+        new(id, (_, page) => page.Raw(message), severity);
 
     /// <summary>
     /// Creates a simple diagnostic template.
@@ -55,11 +41,11 @@ public sealed record DiagnosticTemplate(
     /// A function the diagnostic message onto an <see cref="IDiagnosticPage"/>.
     /// </param>
     /// <param name="severity">The severity of the diagnostic.</param>
-    public static DiagnosticTemplate Create(
+    public static DiagnosticTemplate<Unit> Create(
         DiagnosticId id,
         Action<IDiagnosticPage> writeMessage,
         Severity severity) =>
-        new(id, writeMessage, severity);
+        new(id, (_, page) => writeMessage(page), severity);
 
     /// <summary>
     /// Creates a diagnostic template with an argument used to format its message.
@@ -74,6 +60,14 @@ public sealed record DiagnosticTemplate(
         Action<TArg, IDiagnosticPage> writeMessage,
         Severity severity) =>
         new(id, writeMessage, severity);
+    
+    /// <summary>
+    /// Formats the template into a diagnostic.
+    /// </summary>
+    /// <param name="template">The template to format.</param>
+    /// <param name="location">The location of the diagnostic.</param>
+    public static IDiagnostic Format(this DiagnosticTemplate<Unit> template, Location location) =>
+        template.Format(new Unit(), location);
 }
 
 /// <summary>

--- a/src/compiler/Diagnostics/PartialDiagnostic.cs
+++ b/src/compiler/Diagnostics/PartialDiagnostic.cs
@@ -41,36 +41,6 @@ public interface IPartialDiagnostic
 /// A diagnostic with partial information about its location,
 /// filled in after the fact once exact location information is known.
 /// </summary>
-/// <param name="Template">The template to create the diagnostic from.</param>
-/// <param name="Offset">The offset of the start of the diagnostic relative to the supplied location.</param>
-/// <param name="Width">The width of the diagnostic from its start.</param>
-public sealed record class PartialDiagnostic(
-    DiagnosticTemplate Template,
-    int Offset,
-    int Width)
-    : IPartialDiagnostic
-{
-    IDiagnosticTemplate IPartialDiagnostic.Template => Template;
-
-    public IDiagnostic Format(Source source, int fullPosition)
-    {
-        var span = new TextSpan(
-            start: fullPosition - Offset,
-            end: fullPosition - Offset + Width);
-        
-        return Diagnostic.Create(
-            Template,
-            new Location(source.Name, span));
-    }
-
-    public IPartialDiagnostic AddOffset(int offset) =>
-        new PartialDiagnostic(Template, Offset + offset, Width);
-}
-
-/// <summary>
-/// A diagnostic with partial information about its location,
-/// filled in after the fact once exact location information is known.
-/// </summary>
 /// <typeparam name="TArg">The type of the argument to the template.</typeparam>
 /// <param name="Template">The template to create the diagnostic from.</param>
 /// <param name="Argument">The argument to supply to the template.</param>

--- a/src/compiler/FlowAnalysis/FlowDiagnostics.cs
+++ b/src/compiler/FlowAnalysis/FlowDiagnostics.cs
@@ -5,7 +5,7 @@ namespace Noa.Compiler.FlowAnalysis;
 
 internal static class FlowDiagnostics
 {
-    public static DiagnosticTemplate ReturnOutsideFunction { get; } =
+    public static DiagnosticTemplate<Unit> ReturnOutsideFunction { get; } =
         DiagnosticTemplate.Create(
             "NOA-FLW-001",
             page => page
@@ -15,7 +15,7 @@ internal static class FlowDiagnostics
                 .Raw("."),
             Severity.Error);
     
-    public static DiagnosticTemplate BreakOutsideFunction { get; } =
+    public static DiagnosticTemplate<Unit> BreakOutsideFunction { get; } =
         DiagnosticTemplate.Create(
             "NOA-FLW-002",
             page => page
@@ -25,7 +25,7 @@ internal static class FlowDiagnostics
                 .Raw("."),
             Severity.Error);
     
-    public static DiagnosticTemplate ContinueOutsideFunction { get; } =
+    public static DiagnosticTemplate<Unit> ContinueOutsideFunction { get; } =
         DiagnosticTemplate.Create(
             "NOA-FLW-003",
             page => page

--- a/src/compiler/MiscellaneousDiagnostics.cs
+++ b/src/compiler/MiscellaneousDiagnostics.cs
@@ -5,7 +5,7 @@ namespace Noa.Compiler;
 
 internal static class MiscellaneousDiagnostics
 {
-    public static DiagnosticTemplate TuplesUnsupported { get; } =
+    public static DiagnosticTemplate<Unit> TuplesUnsupported { get; } =
         DiagnosticTemplate.Create(
             "NOA-MISC-001",
             page => page

--- a/src/compiler/Parsing/LexerCore.cs
+++ b/src/compiler/Parsing/LexerCore.cs
@@ -35,8 +35,8 @@ internal sealed partial class Lexer(Source source, CancellationToken cancellatio
             ? Rest.Slice(from, length)
             : [];
     
-    private void ReportDiagnostic(DiagnosticTemplate template, int width) =>
-        diagnosticsForNextToken.Add(new LexerDiagnostic(template, position, width));
+    private void ReportDiagnostic(DiagnosticTemplate<Unit> template, int width) =>
+        diagnosticsForNextToken.Add(new LexerDiagnostic<Unit>(template, new Unit(), position, width));
     
     private void ReportDiagnostic<T>(DiagnosticTemplate<T> template, T arg, int width) =>
         diagnosticsForNextToken.Add(new LexerDiagnostic<T>(template, arg, position, width));

--- a/src/compiler/Parsing/LexerDiagnostic.cs
+++ b/src/compiler/Parsing/LexerDiagnostic.cs
@@ -10,19 +10,6 @@ internal interface ILexerDiagnostic
     IPartialDiagnostic ToPartial(int currentLexerPosition);
 }
 
-internal readonly record struct LexerDiagnostic(
-    DiagnosticTemplate Template,
-    int Position,
-    int Width)
-    : ILexerDiagnostic
-{
-    public IPartialDiagnostic ToPartial(int currentLexerPosition) =>
-        new PartialDiagnostic(
-            Template,
-            Offset: Position - currentLexerPosition,
-            Width);
-}
-
 internal readonly record struct LexerDiagnostic<T>(
     DiagnosticTemplate<T> Template,
     T Arg,

--- a/src/compiler/Parsing/ParseDiagnostics.cs
+++ b/src/compiler/Parsing/ParseDiagnostics.cs
@@ -48,7 +48,7 @@ internal static class ParseDiagnostics
             },
             Severity.Error);
 
-    public static DiagnosticTemplate InvalidExpressionStatement { get; } =
+    public static DiagnosticTemplate<Unit> InvalidExpressionStatement { get; } =
         DiagnosticTemplate.Create(
             "NOA-SYN-004",
             page => page
@@ -73,7 +73,7 @@ internal static class ParseDiagnostics
                 .Raw(")."),
             Severity.Error);
 
-    public static DiagnosticTemplate InvalidLValue { get; } =
+    public static DiagnosticTemplate<Unit> InvalidLValue { get; } =
         DiagnosticTemplate.Create(
             "NOA-SYN-006",
             // "Only identifier expressions can be used on the left-hand side of an assignment statement",
@@ -85,7 +85,7 @@ internal static class ParseDiagnostics
                 .Raw("."),
             Severity.Error);
 
-    public static DiagnosticTemplate ElseOmitted { get; } =
+    public static DiagnosticTemplate<Unit> ElseOmitted { get; } =
         DiagnosticTemplate.Create(
             "NOA-SYN-007",
             page => page
@@ -96,7 +96,7 @@ internal static class ParseDiagnostics
                 .Raw(" can only be omitted when the expression is used as a statement."),
             Severity.Error);
     
-    public static DiagnosticTemplate UnterminatedString { get; } =
+    public static DiagnosticTemplate<Unit> UnterminatedString { get; } =
         DiagnosticTemplate.Create(
             "NOA-SYN-008",
             page => page

--- a/src/compiler/Parsing/ParserCore.cs
+++ b/src/compiler/Parsing/ParserCore.cs
@@ -22,9 +22,10 @@ internal sealed partial class Parser
         this.cancellationToken = cancellationToken;
     }
 
-    private void ReportDiagnostic(DiagnosticTemplate template, SyntaxNode node, int offset = 0) =>
-        node.AddDiagnostic(new PartialDiagnostic(
+    private void ReportDiagnostic(DiagnosticTemplate<Unit> template, SyntaxNode node, int offset = 0) =>
+        node.AddDiagnostic(new PartialDiagnostic<Unit>(
             template,
+            new Unit(),
             Offset: offset,
             Width: node.GetSnugWidth()));
 

--- a/src/compiler/Unit.cs
+++ b/src/compiler/Unit.cs
@@ -1,0 +1,9 @@
+namespace Noa.Compiler;
+
+/// <summary>
+/// A unit type, a type with only one possible value.
+/// </summary>
+public readonly record struct Unit
+{
+    public override string ToString() => "()";
+}


### PR DESCRIPTION
Simplify diagnostics by adding a `Unit` type which diagnostics without arguments use. Also simplify DiagnosticId a bit by using regex instead of a janky untested manual implementation.