### PR TITLE
Change precedence of not operator

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -46,10 +46,11 @@ Operator precedence specifies in what order multiple chained operators parse. Fo
 
 The following is a list of operators and their precedence in order from lowest to highest:
 
-1. `a or b`
-2. `a and b`
-3. `a == b`, `a != b`
-4. `a < b`, `a > b`, `a <= b`, `a >= b`
-5. `a + b`, `a - b`
-6. `a * b`, `a / b`
-7. `+x`, `-x`, `not x`
+1. `not x`
+2. `a or b`
+3. `a and b`
+4. `a == b`, `a != b`
+5. `a < b`, `a > b`, `a <= b`, `a >= b`
+6. `a + b`, `a - b`
+7. `a * b`, `a / b`
+8. `+x`, `-x`

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -44,6 +44,8 @@ Some operators, namely `or` and `and`, only evaluate their right-side operand if
 
 Operator precedence specifies in what order multiple chained operators parse. For instance, `1 + 2 * 3` is equivalent to `1 + (2 * 3)` because `*` has a *higher* precedence than `+`. If two operators with the same precedence are chained, then the operators are evaluated from left to right (all operators in Noa are left-associative).
 
+Notably, `not x` has the highest precedence out of any operator. This is different from most other languages where `!` has the same precedence as the other unary operators `+x` and `-x`. This is because Noa uses keywords for these operators instead of symbols, so that `not a or b` works consistently with the way most people will mentally parse the phrase "not a or b" as "not a or not b".
+
 The following is a list of operators and their precedence in order from lowest to highest:
 
 1. `not x`

--- a/src/compiler/Parsing/Expressions.cs
+++ b/src/compiler/Parsing/Expressions.cs
@@ -89,6 +89,9 @@ internal sealed partial class Parser
         };
     }
 
+    private readonly ExpressionParser notExpressionParser = PrefixUnaryParser(
+        TokenKind.Not);
+
     private readonly ExpressionParser orExpressionParser = LeftBinaryParser(
         TokenKind.Or);
 
@@ -115,8 +118,7 @@ internal sealed partial class Parser
 
     private readonly ExpressionParser unaryExpressionParser = PrefixUnaryParser(
         TokenKind.Plus,
-        TokenKind.Dash,
-        TokenKind.Not);
+        TokenKind.Dash);
 
     internal ExpressionSyntax ParseCallExpression(int precedence)
     {
@@ -325,15 +327,16 @@ internal sealed partial class Parser
     
     internal ExpressionSyntax ParseExpressionOrError(int precedence) => precedence switch
     {
-        0 => orExpressionParser(this, precedence),
-        1 => andExpressionParser(this, precedence),
-        2 => equalityExpressionParser(this, precedence),
-        3 => relationalExpressionParser(this, precedence),
-        4 => termExpressionParser(this, precedence),
-        5 => factorExpressionParser(this, precedence),
-        6 => unaryExpressionParser(this, precedence),
-        7 => ParseCallExpression(precedence),
-        8 => ParsePrimaryExpression(),
+        0 => notExpressionParser(this, precedence),
+        1 => orExpressionParser(this, precedence),
+        2 => andExpressionParser(this, precedence),
+        3 => equalityExpressionParser(this, precedence),
+        4 => relationalExpressionParser(this, precedence),
+        5 => termExpressionParser(this, precedence),
+        6 => factorExpressionParser(this, precedence),
+        7 => unaryExpressionParser(this, precedence),
+        8 => ParseCallExpression(precedence),
+        9 => ParsePrimaryExpression(),
         _ => throw new UnreachableException()
     };
 


### PR DESCRIPTION
Change the precedence of the `not` operator such that `not a or b` is parsed more naturally as "not a or not b".