### PR TITLE
Add --version CLI option

### DIFF
--- a/src/cli/Commands/Root.cs
+++ b/src/cli/Commands/Root.cs
@@ -85,6 +85,11 @@ public sealed class Root(
             Description = "Shows info about how to use the CLI."
         };
 
+        var versionOption = new VersionOption("--version")
+        {
+            Description = "Shows version information."
+        };
+
         var buildCommand = Build.CreateCommand(console);
 
         var langServerCommand = LangServer.CreateCommand(console);
@@ -97,6 +102,7 @@ public sealed class Root(
         command.Add(timeOption);
         command.Add(debugOption);
         command.Add(helpOption);
+        command.Add(versionOption);
         command.Add(buildCommand);
         command.Add(langServerCommand);
 


### PR DESCRIPTION
Add global `--version` option to the CLI. Fixes an issue with the VSCode extension because I forgot including a `--version` option in the previous PR merging the new CLI, which the VSCode extension depends on.