### PR TITLE
Fix parenthesized expressions sometimes parsing incorrectly

### DIFF
--- a/src/compiler/Parsing/ParenthesizedExpression.cs
+++ b/src/compiler/Parsing/ParenthesizedExpression.cs
@@ -50,9 +50,7 @@ internal sealed partial class Parser
                 lockedIn = true;
             }
 
-            if (!lockedIn &&
-                Current.Kind is not TokenKind.Name &&
-                SyntaxFacts.CanBeginExpression.Contains(Current.Kind))
+            if (!lockedIn && !SyntaxFacts.CanBeginLambdaParameter.Contains(Current.Kind))
             {
                 // We found something which can begin an expression and is not a name.
                 // Return to switch to parsing a parenthesized expression.

--- a/src/compiler/Parsing/SyntaxFacts.cs
+++ b/src/compiler/Parsing/SyntaxFacts.cs
@@ -79,6 +79,15 @@ internal static class SyntaxFacts
     }.ToFrozenSet();
 
     /// <summary>
+    /// The set of tokens which can begin a lambda parameter.
+    /// </summary>
+    public static FrozenSet<TokenKind> CanBeginLambdaParameter { get; } = new[]
+    {
+        TokenKind.Mut,
+        TokenKind.Name
+    }.ToFrozenSet();
+
+    /// <summary>
     /// The set of tokens which can be used as an assignment operator.
     /// </summary>
     public static FrozenSet<TokenKind> AssignmentOperator { get; } = new[]


### PR DESCRIPTION
Fix parenthesized binary expressions parsing incorrect if they happen to start with an identifier. Fixes #102 