### PR TITLE
Trigger garbage collection

### DIFF
--- a/src/runtime/src/heap.rs
+++ b/src/runtime/src/heap.rs
@@ -82,7 +82,7 @@ pub enum HeapGetError {
 #[derive(Debug)]
 pub enum HeapAllocError {
     /// The heap is out of available memory.
-    OutOfNoMemory(HeapValue),
+    OutOfMemory(HeapValue),
 }
 
 impl Heap {
@@ -134,7 +134,7 @@ impl Heap {
         // First just check whether there even is memory left to allocate at.
         let address = match self.first_free {
             Some(x) => x,
-            None => return Err(HeapAllocError::OutOfNoMemory(value)), // no more memory
+            None => return Err(HeapAllocError::OutOfMemory(value)), // no more memory
         };
 
         let slot = &mut self.mem[address];
@@ -355,7 +355,7 @@ mod tests {
         
         assert_matches!(
             heap.alloc(HeapValue::String(";w;".into())),
-            Err(HeapAllocError::OutOfNoMemory(_))
+            Err(HeapAllocError::OutOfMemory(_))
         );
 
         assert_matches!(&heap.mem[..], [

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -161,7 +161,7 @@ impl Vm {
     pub fn heap_alloc(&mut self, value: HeapValue) -> Result<HeapAddress> {
         match self.heap.alloc(value) {
             Ok(x) => Ok(x),
-            Err(HeapAllocError::OutOfNoMemory(value)) => {
+            Err(HeapAllocError::OutOfMemory(value)) => {
                 // We're out of heap memory, so do a run of garbage collection.
                 // This is an extremely naïve approach to garbage collection,
                 // although we don't really need much more since we're not really


### PR DESCRIPTION
Trigger garbage collection when attempting to allocate memory while the heap is full. This is an extremely naïve approach to garbage collection, although we don't really need much more since we're not really in the business of performance anyway. Fixes #69.